### PR TITLE
feat(#1): jwt를 이용한 카카오 로그인 회원가입

### DIFF
--- a/src/main/java/com/capstone/bszip/Member/controller/KakaoLoginController.java
+++ b/src/main/java/com/capstone/bszip/Member/controller/KakaoLoginController.java
@@ -1,0 +1,90 @@
+package com.capstone.bszip.Member.controller;
+
+import com.capstone.bszip.Member.service.KakaoService;
+import com.capstone.bszip.Member.service.MemberService;
+import com.capstone.bszip.Member.service.dto.SignupRequest;
+import com.capstone.bszip.Member.service.dto.TokenResponse;
+import com.capstone.bszip.auth.security.JwtUtil;
+import com.capstone.bszip.commonDto.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/kakao/oauth")
+@Tag(name="카카오 로그인", description = "카카오 로그인")
+public class KakaoLoginController {
+    private final KakaoService kakaoService;
+    private final MemberService memberService;
+
+    @ResponseBody
+    @GetMapping("/login")
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code, HttpServletResponse response){
+       String kakaoEmail = kakaoService.getkakaoEmail(code);
+       int loginWay = kakaoService.whichLoginWay(kakaoEmail);
+
+       if(loginWay == 2){
+           return ResponseEntity.ok(
+                   SuccessResponse.builder()
+                           .result(true)
+                           .status(HttpServletResponse.SC_CONFLICT)
+                           .data(null)
+                           .message("기본 로그인으로 로그인해주세요.")
+                           .build()
+           );
+       }
+
+       if(loginWay == 3){
+           try{
+               TokenResponse tokens = kakaoService.loginUser(kakaoEmail);
+               response.addHeader("Authorization","Bearer "+tokens.getAccessToken());
+
+               return ResponseEntity.ok(tokens);
+           }catch (BadCredentialsException e) {
+               return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                       .body(Map.of("error", "잘못된 접근"));
+           }catch(Exception e){
+               return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                       .body(Map.of("message", e.getMessage()));
+           }
+
+       }
+
+       if(loginWay == 1) {
+           try{
+           SignupRequest signupRequest = new SignupRequest();
+           signupRequest.setEmail(kakaoEmail);
+           signupRequest.setPassword("kakao-password");
+           memberService.registerMember(signupRequest);
+
+           String token = JwtUtil.issueTempToken(kakaoEmail);
+           return ResponseEntity.ok()
+                   .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                   .body(Map.of("message", "TEMP_TOKEN_ISSUED"));
+            }
+           catch (Exception e) {
+               return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                       .body(Map.of("message", e.getMessage()));
+           }
+       }
+
+        return ResponseEntity.ok(
+                SuccessResponse.builder()
+                        .result(true)
+                        .status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+                        .data(null)
+                        .message("다시 시도해보세요")
+                        .build()
+        );
+
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/Member/service/KakaoService.java
+++ b/src/main/java/com/capstone/bszip/Member/service/KakaoService.java
@@ -1,0 +1,165 @@
+package com.capstone.bszip.Member.service;
+
+import com.capstone.bszip.Member.domain.Member;
+import com.capstone.bszip.Member.domain.MemberJoinType;
+import com.capstone.bszip.Member.repository.MemberRepository;
+import com.capstone.bszip.Member.service.dto.TokenResponse;
+import com.capstone.bszip.auth.refreshToken.RefreshToken;
+import com.capstone.bszip.auth.refreshToken.RefreshTokenRepository;
+import com.capstone.bszip.auth.security.JwtUtil;
+import com.capstone.bszip.commonDto.SuccessResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final MemberRepository memberRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final Map<String, String> temporaryStorage = new HashMap<>(); // 임시 데이터 저장소
+
+    @Value("${kakao.client.id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Transactional
+    public String getkakaoEmail(String code){
+        String redirectUri = this.redirectUri;
+        // 프론트에서 준 인가 코드로 카카오의 액세스 토큰 요청
+        String kakaoAccessToken = getKakaoAccessToken(code, redirectUri);
+
+        // 가져온 토큰으로 카카오 api 호출
+        HashMap<String, Object> memberInfo = getKakaoMemberInfo(kakaoAccessToken);
+        return memberInfo.get("email").toString();
+    }
+
+    @Transactional
+    public String getKakaoAccessToken(String code, String redirectUri){
+        // http 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+
+        // http로 요청하여 엑세스 토큰 받기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class);
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = null;
+        try{
+            jsonNode = objectMapper.readTree(responseBody);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return jsonNode.get("access_token").asText(); // 토큰 전송
+    }
+
+    private HashMap<String, Object> getKakaoMemberInfo(String accessToken){
+        HashMap<String, Object> memberInfo = new HashMap<>();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Accept", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // responsebody에 있는 정보 꺼내기
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = null;
+        try{
+            jsonNode = objectMapper.readTree(responseBody);
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+        Long id = jsonNode.get("id").asLong();
+        String email = jsonNode.get("kakao_account").get("email").asText();
+
+        memberInfo.put("id", id);
+        memberInfo.put("email", email);
+
+        return memberInfo;
+    }
+
+    // 기본 로그인으로 회원가입된 상황
+    public int whichLoginWay(String kakaoEmail){
+
+        Member member = memberRepository.findByEmail(kakaoEmail).orElse(null);
+
+        if(member == null){
+            // 회원가입 시켜야 돼
+            return 1;
+        }else if(member.getMemberJoinType().equals(MemberJoinType.DEFAULT)){
+            // 기본 로그인으로 로그인하라고 알려줘
+            return 2;
+        }
+
+        // 카카오 로그인 시키면 돼..
+        return 3;
+
+    }
+
+    public void updateRefreshToken(String email,String refreshToken){
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+        if(memberOptional.isPresent()){
+            Member member = memberOptional.get();
+            RefreshToken token = new RefreshToken();
+            token.setMemberId(member.getMemberId());
+            token.setRefreshToken(refreshToken);
+            token.setExpiryDate(Instant.now().plusSeconds(7 * 24 * 60 * 60));
+
+            refreshTokenRepository.save(token);
+        }
+    }
+
+    public TokenResponse loginUser(String kakaoEmail){
+        String accessToken = JwtUtil.createAccessToken(kakaoEmail);
+        String refreshToken = JwtUtil.createRefreshToken(kakaoEmail);
+        //refresh 토큰 db 저장
+        updateRefreshToken(kakaoEmail,refreshToken);
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,6 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 springdoc.show-actuator=true
+
+kakao.client.id=${kakao.client.id}
+kakao.redirect-uri=${kakao.redirect-uri}


### PR DESCRIPTION

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

* 기존의 memberSerive를 이용해서 카카오 로그인 및 회원가입 구현했습니다.
  * 기존의 memberService 재활용을 위해서 /signup/add 부분에서 DEFAULT와 KAKAO 타입을 구분하여 저장하도록 하는 코드를 추가했습니다.
  <br/>

## 이미지 첨부



<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [Backend #1 ](https://github.com/TEAM-ZIP/Backend/issues/1#issue-2798815625)

<br/>
