### PR TITLE
feat(#23): 서점 검색 기능 구현

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -1,0 +1,30 @@
+package com.capstone.bszip.Bookstore.controller;
+
+import com.capstone.bszip.Bookstore.service.BookstoreService;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/* 프론트
+const response = await fetch(`/api/bookstores/search?keyword=${searchWord}`);
+    const data = await response.json();
+
+    setSearchResults(data); // 검색 결과 업데이트
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookstores")
+@Tag(name = "Bookstore", description = "서점 관리 API")
+public class BookstoreController {
+    private final BookstoreService bookstoreService;
+    @GetMapping("/search")
+    public List<BookstoreResponse>  searchBookstores(@RequestParam String keyword) {
+        return bookstoreService.searchBookstores(keyword);
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -1,0 +1,54 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class BookstoreService {
+    private final RestTemplate restTemplate= new RestTemplate();
+
+    private static final String API_URL = "http://api.kcisa.kr/openapi/API_CIA_090/request"; //open api url
+    @Value("${bookstore.cafe.key}")
+    private String BOOKSTORE_CAFE_KEY;
+
+    public List<BookstoreResponse> searchBookstores(String keyword) {
+        String url = UriComponentsBuilder.fromHttpUrl(API_URL)
+                .queryParam("serviceKey", BOOKSTORE_CAFE_KEY)
+                .queryParam("numOfRows", 10)
+                .queryParam("pageNo", 1)
+                .queryParam("keyword", keyword)
+                .build()
+                .toString();
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        List<BookstoreResponse> bookstoreList = new ArrayList<>();
+
+        if (response != null ) {
+            Map<String, Object> responseData = (Map<String, Object>) response.get("response");
+            Map<String, Object> body = (Map<String, Object>) responseData.get("body");
+            Map<String, Object> items = (Map<String, Object>) body.get("items");
+            List<Map<String, Object>> dataList = (List<Map<String, Object>>) items.get("item");
+
+            for (Map<String, Object> item : dataList) {
+                BookstoreResponse bookstoreResponse = new BookstoreResponse();
+                bookstoreResponse.setName((String) item.get("TITLE"));
+                // bookstoreResponse.setRating(); // 별점은 따로 계산해야함
+                bookstoreResponse.setCategory("카페가 있는 서점");
+                bookstoreResponse.setPhone((String) item.get("CONTACT_POINT"));
+                bookstoreResponse.setHours((String) item.get("DESCRIPTION"));
+                bookstoreResponse.setAddress((String) item.get("ADDRESS"));
+                bookstoreResponse.setDescription((String) item.get("SUB_DESCRIPTION"));
+                bookstoreList.add(bookstoreResponse);
+            }
+        }
+        return bookstoreList; //서점 검색 결과 리스트 반환
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreResponse.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreResponse.java
@@ -1,0 +1,14 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import lombok.Data;
+
+@Data
+public class BookstoreResponse {
+    private String name;
+    //private double rating; 별점 _ 리뷰 후에
+    private String category;
+    private String phone;
+    private String hours;
+    private String address;
+    private String description;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,7 @@ springdoc.show-actuator=true
 
 kakao.client.id=${kakao.client.id}
 kakao.redirect-uri=${kakao.redirect-uri}
+
+bookstore.cafe.key=${BOOKSTORE_CAFE_KEY}
+bookstore.indep.key=${BOOKSTORE_INDEP_KEY}
+bookstore.child.key=${BOOKSTORE_CHILD_KEY}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 서점 ZIP 가기에서 검색 창에 서점 키워드를 입력하면 open api에 연결해서 반환하는 코드 추가했습니다 !
- 궁금한점 ... 이 검색을 어디서 하는 걸까요 .. 카페+아동+독립 api 세개 다 검색해서 반환하는 걸지 ... 아니면 카카오지도 api에서 키워드 검색을 제공하는 거 같은데 .. 이렇게 검색을 할지 .....

- (일단은 카페가 있는 서점 대표로 검색되도록 했습니닷)

  <br/>

## 이미지 첨부


![image](https://github.com/user-attachments/assets/c1ab4337-13a2-48c4-bbd1-c705ebda405e)

<br/>

## 🔧 앞으로의 과제

- 키워드 검색 기능 구현 하겠음 😄 

  <br/>

## ➕ 이슈 링크

- [Backend #23](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
