### PR TITLE
update(#22): 책 검색

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -1,5 +1,6 @@
 package com.capstone.bszip.Book.controller;
 
+import com.capstone.bszip.Book.dto.AddIsEndBookResponse;
 import com.capstone.bszip.Book.dto.BookSearchResponse;
 import com.capstone.bszip.Book.service.BookReviewService;
 import com.capstone.bszip.commonDto.SuccessResponse;
@@ -59,15 +60,15 @@ public class BookReviewController {
                         "]" +
                         "}"
         )})),})
-    public ResponseEntity<?> searchBookByTitle(@RequestParam String titleQuery) {
+    public ResponseEntity<?> searchBookByTitle(@RequestParam String query) {
         try{
-            String bookJson = bookReviewService.searchBooksByTitle(titleQuery);
-            List<BookSearchResponse> bookSearchResponses = bookReviewService.convertToBookSearchResponse(bookJson);
+            String bookJson = bookReviewService.searchBooksByTitle(query);
+            AddIsEndBookResponse addIsEndBookResponse = bookReviewService.convertToBookSearchResponse(bookJson);
             return ResponseEntity.ok(
                     SuccessResponse.builder()
                             .result(true)
                             .status(HttpServletResponse.SC_OK)
-                            .data(bookSearchResponses)
+                            .data(addIsEndBookResponse) // 현재 페이지가 끝인지 확인할 수 있는 것도 추가해야 될듯..!
                             .message("검색 성공")
                             .build()
             );
@@ -80,15 +81,15 @@ public class BookReviewController {
      * 작가로 도서 검색 api
      * - 책 ID, 이미지 url, 책 제목, 작가,출판사 제공*/
     @GetMapping("/book-search-by-author")
-    public ResponseEntity<?> searchBookByAuthor(@RequestParam String authorQuery) {
+    public ResponseEntity<?> searchBookByAuthor(@RequestParam String query) {
         try{
-            String bookJson = bookReviewService.searchBooksByAuthor(authorQuery);
-            List<BookSearchResponse> bookSearchResponses = bookReviewService.convertToBookSearchResponse(bookJson);
+            String bookJson = bookReviewService.searchBooksByAuthor(query);
+            AddIsEndBookResponse addIsEndBookResponse = bookReviewService.convertToBookSearchResponse(bookJson);
             return ResponseEntity.ok(
                     SuccessResponse.builder()
                             .result(true)
                             .status(HttpServletResponse.SC_OK)
-                            .data(bookSearchResponses)
+                            .data(addIsEndBookResponse)
                             .message("검색 성공")
                             .build()
             );
@@ -96,6 +97,12 @@ public class BookReviewController {
             throw new RuntimeException(e);
         }
     }
+    /*
+    * 더 많은 책 불러오기 api
+    *
+    * */
+
+
     /*
     * 리뷰 작성 api
     * - 책 ID, 별점, 리뷰 받아서 저장*/

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -78,7 +79,7 @@ public class BookReviewController {
     /*
      * 작가로 도서 검색 api
      * - 책 ID, 이미지 url, 책 제목, 작가,출판사 제공*/
-    @GetMapping("/book-search")
+    @GetMapping("/book-search-by-author")
     public ResponseEntity<?> searchBookByAuthor(@RequestParam String authorQuery) {
         try{
             String bookJson = bookReviewService.searchBooksByAuthor(authorQuery);
@@ -95,7 +96,6 @@ public class BookReviewController {
             throw new RuntimeException(e);
         }
     }
-
     /*
     * 리뷰 작성 api
     * - 책 ID, 별점, 리뷰 받아서 저장*/

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -60,9 +60,9 @@ public class BookReviewController {
                         "]" +
                         "}"
         )})),})
-    public ResponseEntity<?> searchBookByTitle(@RequestParam String query) {
+    public ResponseEntity<?> searchBookByTitle(@RequestParam String query, @RequestParam(required = false, defaultValue = "1")int page) {
         try{
-            String bookJson = bookReviewService.searchBooksByTitle(query);
+            String bookJson = bookReviewService.searchBooksByTitle(query, page);
             AddIsEndBookResponse addIsEndBookResponse = bookReviewService.convertToBookSearchResponse(bookJson);
             return ResponseEntity.ok(
                     SuccessResponse.builder()
@@ -81,9 +81,9 @@ public class BookReviewController {
      * 작가로 도서 검색 api
      * - 책 ID, 이미지 url, 책 제목, 작가,출판사 제공*/
     @GetMapping("/book-search-by-author")
-    public ResponseEntity<?> searchBookByAuthor(@RequestParam String query) {
+    public ResponseEntity<?> searchBookByAuthor(@RequestParam String query, @RequestParam(required = false, defaultValue = "1")int page) {
         try{
-            String bookJson = bookReviewService.searchBooksByAuthor(query);
+            String bookJson = bookReviewService.searchBooksByAuthor(query, page);
             AddIsEndBookResponse addIsEndBookResponse = bookReviewService.convertToBookSearchResponse(bookJson);
             return ResponseEntity.ok(
                     SuccessResponse.builder()

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -25,7 +25,7 @@ public class BookReviewController {
 
     private final BookReviewService bookReviewService;
     /*
-    * 도서 검색 api
+    * 제목으로 도서 검색 api
     * - 책 ID, 이미지 url, 책 제목, 작가,출판사 제공*/
     @GetMapping("/book-search")
     @Operation(summary = "책 검색", description = "책 제목을 입력하여 책제목, 작가, 출판사, isbn, 책 표지 url을 검색하여 볼러옵니다.")
@@ -58,9 +58,30 @@ public class BookReviewController {
                         "]" +
                         "}"
         )})),})
-    public ResponseEntity<?> searchBookByTitle(@RequestParam String query) {
+    public ResponseEntity<?> searchBookByTitle(@RequestParam String titleQuery) {
         try{
-            String bookJson = bookReviewService.searchBooksByTitle(query);
+            String bookJson = bookReviewService.searchBooksByTitle(titleQuery);
+            List<BookSearchResponse> bookSearchResponses = bookReviewService.convertToBookSearchResponse(bookJson);
+            return ResponseEntity.ok(
+                    SuccessResponse.builder()
+                            .result(true)
+                            .status(HttpServletResponse.SC_OK)
+                            .data(bookSearchResponses)
+                            .message("검색 성공")
+                            .build()
+            );
+        } catch (Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    /*
+     * 작가로 도서 검색 api
+     * - 책 ID, 이미지 url, 책 제목, 작가,출판사 제공*/
+    @GetMapping("/book-search")
+    public ResponseEntity<?> searchBookByAuthor(@RequestParam String authorQuery) {
+        try{
+            String bookJson = bookReviewService.searchBooksByAuthor(authorQuery);
             List<BookSearchResponse> bookSearchResponses = bookReviewService.convertToBookSearchResponse(bookJson);
             return ResponseEntity.ok(
                     SuccessResponse.builder()

--- a/src/main/java/com/capstone/bszip/Book/dto/AddIsEndBookResponse.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/AddIsEndBookResponse.java
@@ -1,0 +1,23 @@
+package com.capstone.bszip.Book.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "끝까지 포함된 책 data 인지 확인 + 기존 책 response 추가한 DTO")
+public class AddIsEndBookResponse {
+
+    @Schema(description = "다 검색된 건지 안된 건지 알려줌",example = "true")
+    private Boolean isEnd;
+
+    @Schema(description = "기존 책 response")
+    private List<BookSearchResponse> bookData;
+}

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
@@ -34,7 +34,7 @@ public class BookReviewService {
     }
 
     // kakao book api에서 책 제목로 검색된 책 정보 json 가져오기 -> 책제목 검색이랑 작가 검색이랑 너무 공통되는 부분이 많아서 걍 통일시켜야 될 거 같으다...
-    public String searchBooksByTitle(String title) throws Exception {
+    public String searchBooksByTitle(String title, int page) throws Exception {
         try{
             String kakaoUri = "https://dapi.kakao.com/v3/search/book";
             // http 헤더 설정
@@ -46,6 +46,7 @@ public class BookReviewService {
             UriComponents uri = UriComponentsBuilder.fromHttpUrl(kakaoUri)
                     .queryParam("query", title)
                     .queryParam("target", "title")
+                    .queryParam("page", page)
                     .build();
 
             // kakao api 책 검색
@@ -71,7 +72,7 @@ public class BookReviewService {
         }
     }
 
-    public String searchBooksByAuthor(String author) throws Exception {
+    public String searchBooksByAuthor(String author, int page) throws Exception {
         try{
             String kakaoUri = "https://dapi.kakao.com/v3/search/book";
             // http 헤더 설정
@@ -83,6 +84,7 @@ public class BookReviewService {
             UriComponents uri = UriComponentsBuilder.fromHttpUrl(kakaoUri)
                     .queryParam("query", author)
                     .queryParam("target", "person")
+                    .queryParam("page", page)
                     .build();
 
             // kakao api 책 검색

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
@@ -1,9 +1,11 @@
 package com.capstone.bszip.Book.service;
 
+import com.capstone.bszip.Book.dto.AddIsEndBookResponse;
 import com.capstone.bszip.Book.dto.BookSearchResponse;
 import com.capstone.bszip.Book.repository.BookRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,11 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+@Slf4j
 @Service
 public class BookReviewService {
     private final BookRepository bookRepository;
     private final ObjectMapper objectMapper;
-
     @Value("${kakao.client.id}")
     private String kakaoApiKey;
 
@@ -31,7 +33,7 @@ public class BookReviewService {
         this.objectMapper = objectMapper;
     }
 
-    // kakao book api에서 책 제목로 검색된 책 정보 json 가져오기
+    // kakao book api에서 책 제목로 검색된 책 정보 json 가져오기 -> 책제목 검색이랑 작가 검색이랑 너무 공통되는 부분이 많아서 걍 통일시켜야 될 거 같으다...
     public String searchBooksByTitle(String title) throws Exception {
         try{
             String kakaoUri = "https://dapi.kakao.com/v3/search/book";
@@ -106,18 +108,26 @@ public class BookReviewService {
         }
     }
 
+    /*
+    * 지금 문제 query만 생각해서 제목이나 작가로 검색할 때 query가 같아도 증가됨...
+    * 그리고 지금은 유저가 한명이지만,, 여러명의 유저가 같은 걸 검색하면 어카냐...
+    * 그냥 url을 [더보기]랑 / [처음 검색]이랑 분리하는 게 나을 듯....
+    * */
 
     // 역직렬화 - Jackson
-    public List<BookSearchResponse> convertToBookSearchResponse(String bookJson){
+    public AddIsEndBookResponse convertToBookSearchResponse(String bookJson){
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode rootNode = objectMapper.readTree(bookJson);
+            // 페이지가 끝인지 아닌지 확인하기 위해서...
+            JsonNode meta = rootNode.get("meta");
+            boolean is_end = meta.get("is_end").asBoolean(); // is_end가 true면 더 이상받을 검색 결과가 없닷
             JsonNode documents = rootNode.path("documents");
 
             List<BookSearchResponse> bookSearchResponses = new ArrayList<>();
-
+            String title = "";
             for (JsonNode document : documents) {
-                String title = document.path("title").asText();
+                title = document.path("title").asText();
                 List<String> authorsList = new ArrayList<>();
 
                 for (JsonNode authorNode : document.path("authors")) {
@@ -131,7 +141,10 @@ public class BookReviewService {
 
                 bookSearchResponses.add(new BookSearchResponse(title, authorsList, publisher, isbn, thumbnail));
             }
-            return bookSearchResponses;
+            AddIsEndBookResponse addIsEndBookResponse = new AddIsEndBookResponse();
+            addIsEndBookResponse.setBookData(bookSearchResponses);
+            addIsEndBookResponse.setIsEnd(is_end);
+            return addIsEndBookResponse;
         } catch (Exception e) {
             throw new RuntimeException("JSON 변환 오류: " + e.getMessage(), e);
         }

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
@@ -80,7 +80,7 @@ public class BookReviewService {
             // 쿼리 파라미터 설정
             UriComponents uri = UriComponentsBuilder.fromHttpUrl(kakaoUri)
                     .queryParam("query", author)
-                    .queryParam("target", "title")
+                    .queryParam("target", "person")
                     .build();
 
             // kakao api 책 검색


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- **작가로 책 검색**할 수 있게 했습니다!
- isEnd 추가해서 현재 값이 **마지막 데이터인지 아닌지 확인**할 수 있게끔 했습니다.
- 더보기를 눌렀을 때, param으로 page값을 받아서 페이지 수 증가시켜 보여주게끔 했습니다.

프론트엔드에서 page 값을 받지 않고 자동으로 증가시키는 방법은 없는지 고민도 해보고, 찾아보기도 했는데...!
> 이 경우에는 프론트엔드에서 page 값을 넘겨받는 것이 일반적입니다.
> 
> 🔹 이유
> 프론트엔드가 사용자 행동을 기반으로 페이지 관리를 하기 때문
> 
> 사용자가 "더보기" 버튼을 클릭하면 새로운 데이터를 불러와야 하므로, 프론트엔드에서 page 값을 직접 관리하는 것이 자연스럽습니다.
> 백엔드가 자동으로 증가시킨다면, 어떤 클라이언트가 요청했는지 상관없이 페이지가 증가하여 비동기 요청 시 예측 불가능한 문제가 발생할 수 있습니다.
> API 요청이 stateless(무상태) 해야 함
> 
> RESTful API에서는 서버가 특정 클라이언트의 상태를 유지하지 않는 것이 일반적입니다.
> 페이지 번호를 서버가 관리하면, 다중 사용자 요청을 처리할 때 혼란이 생길 수 있습니다.
> 백엔드에서 여러 클라이언트가 동시에 요청하는 경우 충돌 가능성
> 
> 예를 들어, A 사용자가 page=1을 요청한 후 B 사용자가 page=2를 요청하면, 서버가 관리하는 페이지 상태가 꼬일 수 있습니다.
> 클라이언트가 직접 page를 지정하면 이런 충돌을 방지할 수 있습니다.

실제로 구현하려고 하니까 다중 사용자 요청에 의한 오류가 발생하더라고요 😅
그래서 프론트엔드에서 page를 넘겨받기로 했습니당


  <br/>

## 이미지 첨부



<br/>

## 🔧 앞으로의 과제

- 리뷰 저장
- 리뷰 보여주기
- 리뷰 필터
- 지금 사용 중인 비밀번호가 임시 비밀번호인지 아닌지 확인할 수 있게 

  <br/>

## ➕ 이슈 링크

- [Backend #22](https://github.com/TEAM-ZIP/Backend/issues/22#issue-2840801056)

<br/>
