### PR TITLE
feat(#23) : 서점 DB 저장 -> 검색, 카테고리 검색 기능

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -1,0 +1,56 @@
+package com.capstone.bszip.Bookstore.controller;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.service.BookstoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookstores")
+@Tag(name = "Bookstore", description = "서점 관리 API")
+public class BookstoreController {
+    private final BookstoreService bookstoreService;
+
+    @Operation(summary = "서점 검색", description = "검색창에서 서점을 이름,주소로 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공",
+                    content = @Content(schema = @Schema(implementation = Bookstore.class))),
+            @ApiResponse(responseCode = "404", description = "검색 결과 없음",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @GetMapping("/search")
+    public ResponseEntity<?> searchBookstores(@RequestParam String keyword) {
+        try {
+            List<Bookstore> bookstores = bookstoreService.searchBookstores(keyword);
+            if (bookstores.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body("검색어에 해당하는 서점이 없습니다.");
+            }
+            return ResponseEntity.ok(bookstores);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("잘못된 검색어입니다: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("서버 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -1,13 +1,16 @@
 package com.capstone.bszip.Bookstore.controller;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.service.BookstoreService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,7 @@ import java.util.List;
 @RequestMapping("/api/bookstores")
 @Tag(name = "Bookstore", description = "서점 관리 API")
 public class BookstoreController {
+
     private final BookstoreService bookstoreService;
 
     @Operation(summary = "서점 검색", description = "검색창에서 서점을 이름,주소로 검색합니다.")
@@ -48,6 +52,27 @@ public class BookstoreController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("잘못된 검색어입니다: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("서버 오류가 발생했습니다.");
+        }
+    }
+
+    @Operation(
+            summary = "카테고리별 서점 조회",
+            description = "지정된 카테고리에 해당하는 서점 목록을 반환합니다. 카테고리가 지정되지 않으면 모든 서점을 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 서점 목록을 반환"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @GetMapping
+    public ResponseEntity<?> getBookstoresByCategory(
+            @Parameter(description = "조회할 서점 카테고리 (선택사항)") @RequestParam(required = false) BookstoreCategory category){
+        try{
+            List<Bookstore> bookstores = bookstoreService.getBookstoresByCategory(category);
+            return ResponseEntity.ok(bookstores);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("서버 오류가 발생했습니다.");

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
@@ -1,0 +1,34 @@
+package com.capstone.bszip.Bookstore.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name="bookstores")
+public class Bookstore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="bookstore_id")
+    private Long bookstoreId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category",nullable = false)
+    private BookstoreCategory bookstoreCategory;
+
+    @Column(name = "phone")
+    private String phone;
+
+    @Column(name = "hours")
+    private String hours;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "description")
+    private String description;
+
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/BookstoreCategory.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/BookstoreCategory.java
@@ -1,0 +1,5 @@
+package com.capstone.bszip.Bookstore.domain;
+
+public enum BookstoreCategory {
+    CAFE,INDEP,CHILD
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookstoreRepository extends JpaRepository<Bookstore,Long> {
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
@@ -3,5 +3,9 @@ package com.capstone.bszip.Bookstore.repository;
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BookstoreRepository extends JpaRepository<Bookstore,Long> {
+    List<Bookstore> findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(String name, String address);
+
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.bszip.Bookstore.repository;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,4 @@ import java.util.List;
 public interface BookstoreRepository extends JpaRepository<Bookstore,Long> {
     List<Bookstore> findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(String name, String address);
 
-}
+    List<Bookstore> findByBookstoreCategory(BookstoreCategory category);}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -1,0 +1,20 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookstoreService {
+    private final BookstoreRepository bookstoreRepository;
+    @Transactional
+    public List<Bookstore> searchBookstores(String keyword) {
+        return bookstoreRepository.findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(keyword,keyword);
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -1,6 +1,7 @@
 package com.capstone.bszip.Bookstore.service;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,14 @@ public class BookstoreService {
     @Transactional
     public List<Bookstore> searchBookstores(String keyword) {
         return bookstoreRepository.findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(keyword,keyword);
+    }
+
+    @Transactional
+    public List<Bookstore> getBookstoresByCategory(BookstoreCategory category){
+        if(category == null){
+            return bookstoreRepository.findAll();
+        }
+        return bookstoreRepository.findByBookstoreCategory(category);
     }
 
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
@@ -2,8 +2,6 @@ package com.capstone.bszip.Bookstore.service;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
-import jakarta.annotation.PostConstruct;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -31,7 +29,7 @@ public class OpenApiService {
     @Value("${bookstore.child.key}")
     private String BOOKSTORE_CHILD_KEY;
 
-    @PostConstruct
+    //@PostConstruct
     public void saveCafeData() {
         String urlCafe = UriComponentsBuilder.fromHttpUrl(API_URL_CAFE)
                 .queryParam("serviceKey", BOOKSTORE_CAFE_KEY)
@@ -58,7 +56,7 @@ public class OpenApiService {
         }
     }
 
-    @PostConstruct
+    //@PostConstruct
     public void saveIndepData() {
         String urlIndep = UriComponentsBuilder.fromHttpUrl(API_URL_INDEP)
                 .queryParam("serviceKey", BOOKSTORE_INDEP_KEY)
@@ -84,7 +82,7 @@ public class OpenApiService {
             bookstoreRepository.save(bookstore);
         }
     }
-    @PostConstruct
+    //@PostConstruct
     public void saveChildData() {
         String urlChild = UriComponentsBuilder.fromHttpUrl(API_URL_CHILD)
                 .queryParam("serviceKey", BOOKSTORE_CHILD_KEY)

--- a/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
@@ -1,0 +1,123 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.capstone.bszip.Bookstore.domain.BookstoreCategory.*;
+
+@Service
+@RequiredArgsConstructor
+public class OpenApiService {
+    private final BookstoreRepository bookstoreRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String API_URL_CAFE = "http://api.kcisa.kr/openapi/API_CIA_090/request";
+    private static final String API_URL_INDEP = "http://api.kcisa.kr/openapi/API_CIA_089/request";
+    private static final String API_URL_CHILD = "http://api.kcisa.kr/openapi/service/CNV/API_CNV_037";
+
+    @Value("${bookstore.cafe.key}")
+    private String BOOKSTORE_CAFE_KEY;
+    @Value("${bookstore.indep.key}")
+    private String BOOKSTORE_INDEP_KEY;
+    @Value("${bookstore.child.key}")
+    private String BOOKSTORE_CHILD_KEY;
+
+    @PostConstruct
+    public void saveCafeData() {
+        String urlCafe = UriComponentsBuilder.fromHttpUrl(API_URL_CAFE)
+                .queryParam("serviceKey", BOOKSTORE_CAFE_KEY)
+                .queryParam("numOfRows", 10) //테스트로 10개만
+                .queryParam("pageNo", 1)
+                .build()
+                .toString();
+        Map<String, Object> responseCafe = restTemplate.getForObject(urlCafe, Map.class);
+        System.out.println(responseCafe);
+        Map<String, Object> responseData = (Map<String, Object>) responseCafe.get("response");
+        Map<String, Object> body = (Map<String, Object>) responseData.get("body");
+        Map<String, Object> items = (Map<String, Object>) body.get("items");
+        List<Map<String, Object>> dataList = (List<Map<String, Object>>) items.get("item");
+
+        for (Map<String, Object> item : dataList) {
+            Bookstore bookstore = new Bookstore();
+            bookstore.setName((String) item.get("TITLE"));
+            bookstore.setBookstoreCategory(CAFE);
+            bookstore.setPhone((String) item.get("CONTACT_POINT"));
+            bookstore.setHours((String) item.get("DESCRIPTION"));
+            bookstore.setAddress((String) item.get("ADDRESS"));
+            bookstore.setDescription((String) item.get("SUB_DESCRIPTION"));
+            bookstoreRepository.save(bookstore);
+        }
+    }
+
+    @PostConstruct
+    public void saveIndepData() {
+        String urlIndep = UriComponentsBuilder.fromHttpUrl(API_URL_INDEP)
+                .queryParam("serviceKey", BOOKSTORE_INDEP_KEY)
+                .queryParam("numOfRows", 10) //테스트로 10개만
+                .queryParam("pageNo", 1)
+                .build()
+                .toString();
+        Map<String, Object> responseIndep = restTemplate.getForObject(urlIndep, Map.class);
+        System.out.println(responseIndep);
+        Map<String, Object> responseData = (Map<String, Object>) responseIndep.get("response");
+        Map<String, Object> body = (Map<String, Object>) responseData.get("body");
+        Map<String, Object> items = (Map<String, Object>) body.get("items");
+        List<Map<String, Object>> dataList = (List<Map<String, Object>>) items.get("item");
+
+        for (Map<String, Object> item : dataList) {
+            Bookstore bookstore = new Bookstore();
+            bookstore.setName((String) item.get("TITLE"));
+            bookstore.setBookstoreCategory(INDEP);
+            bookstore.setPhone((String) item.get("CONTACT_POINT"));
+            bookstore.setHours((String) item.get("DESCRIPTION"));
+            bookstore.setAddress((String) item.get("ADDRESS"));
+            bookstore.setDescription((String) item.get("SUB_DESCRIPTION"));
+            bookstoreRepository.save(bookstore);
+        }
+    }
+    @PostConstruct
+    public void saveChildData() {
+        String urlChild = UriComponentsBuilder.fromHttpUrl(API_URL_CHILD)
+                .queryParam("serviceKey", BOOKSTORE_CHILD_KEY)
+                .queryParam("numOfRows", 10) //테스트로 10개만
+                .queryParam("pageNo", 1)
+                .build()
+                .toString();
+        Map<String, Object> responseChild = restTemplate.getForObject(urlChild, Map.class);
+        System.out.println(responseChild);
+        Map<String, Object> responseData = (Map<String, Object>) responseChild.get("response");
+        Map<String, Object> body = (Map<String, Object>) responseData.get("body");
+        Map<String, Object> items = (Map<String, Object>) body.get("items");
+        List<Map<String, Object>> dataList = (List<Map<String, Object>>) items.get("item");
+
+        for (Map<String, Object> item : dataList) {
+            Bookstore bookstore = new Bookstore();
+            bookstore.setName((String) item.get("FCLTY_NM"));
+            bookstore.setBookstoreCategory(CHILD);
+            bookstore.setPhone("0" + (String) item.get("TEL_NO"));
+            bookstore.setHours("평일개점마감시간" + convertDecimalToTime(item.get("WORKDAY_OPN_BSNS_TIME")) + "~" + convertDecimalToTime(item.get("WORKDAY_CLOS_TIME"))
+                    + "토요일개점마감시간" + convertDecimalToTime(item.get("SAT_OPN_BSNS_TIME")) + "~" + convertDecimalToTime(item.get("SAT_CLOS_TIME"))
+                    + "일요일개점마감시간" + convertDecimalToTime(item.get("SUN_OPN_BSNS_TIME")) + "~" + convertDecimalToTime(item.get("SUN_CLOS_TIME")));
+            bookstore.setAddress((String) item.get("FCLTY_ROAD_NM_ADDR"));
+            bookstore.setDescription((String) item.get("ADIT_DC"));
+            bookstoreRepository.save(bookstore);
+        }
+    }
+    public static String convertDecimalToTime(Object decimalTime) {
+        if (decimalTime == null) return "";
+        double time = Double.parseDouble(decimalTime.toString());
+        int totalMinutes = (int) Math.round(time * 24 * 60);
+        int hours = totalMinutes / 60;
+        int minutes = totalMinutes % 60;
+        return String.format("%02d:%02d", hours, minutes);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,7 @@ springdoc.show-actuator=true
 
 kakao.client.id=${kakao.client.id}
 kakao.redirect-uri=${kakao.redirect-uri}
+
+bookstore.cafe.key=${BOOKSTORE_CAFE_KEY}
+bookstore.indep.key=${BOOKSTORE_INDEP_KEY}
+bookstore.child.key=${BOOKSTORE_CHILD_KEY}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 아동서점 api가 keyword 검색이 안돼서 전체를 불러와서 필터링하는 방법밖에 없었기 때문에.. 😂 
 아예 Bookstore 도메인을 만들어서 DB에 저장하는 로직으로 바꿨습니다

- 1. 프로그램 실행시 openAPI에서 서점 정보를 가져와서 db에 저장하고 *지금은 테스트로 10개씩 저장됨

- 2. db에서 서점 이름, 주소로 검색한 결과를 반환함

- 3. db에서 카테고리별 서점 결과를 반환함

  <br/>

## 이미지 첨부

1. db에 저장된 서점 정보

![image](https://github.com/user-attachments/assets/918c3897-bb10-436f-b4fa-2068a0412a0e)

  <br/>

2.  swagger 검색 결과 *어노테이션 추가함!!

![image](https://github.com/user-attachments/assets/d0e8a35e-be78-4114-85d8-718ebd6a6f56)


3. swagger 카테고리 검색 결과 ***전체 서점 카테고리도 추가할 수 있음 !! 있는게 좋을거 같은데 어떤지 ..

![image](https://github.com/user-attachments/assets/b4ac62fb-4916-44ee-9be3-51f1f60b0376)

<br/>

## 🔧 앞으로의 과제

- 내가 찜한 서점 

  <br/>

## ➕ 이슈 링크

- [Backend #23](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
