### PR TITLE
feat(#22): 책 한 줄 리뷰 좋아요 생성 및 삭제

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
@@ -3,21 +3,17 @@ package com.capstone.bszip.Book.controller;
 import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.BookReviewLikes;
 import com.capstone.bszip.Book.dto.BookReviewLikeRequest;
-import com.capstone.bszip.Book.dto.BookSearchResponse;
 import com.capstone.bszip.Book.service.BookReviewLikeService;
 import com.capstone.bszip.Book.service.BookReviewService;
 import com.capstone.bszip.Member.domain.Member;
 import com.capstone.bszip.commonDto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,10 +42,13 @@ public class BookReviewLikeController {
             // 멤버 가지고 오기
             Member member = (Member) authentication.getPrincipal();
             // 해당 책 한 줄 리뷰 가지고 오기
-            //[추가] 유저가 이미 좋아요한 것인지도 판단헤주면 좋을 듯!!
             Long bookReviewId = bookReviewLikeRequest.getBookReviewId();
             BookReview bookReview = bookReviewService.getBookReviewById(bookReviewId);
-
+            if(bookReviewLikeService.isAleadyLiked(bookReview, member)){
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                        member.getNickname()+"님이 이미 좋아요하셨습니다...😅"
+                );
+            }
             // 좋아요 객체 만들기
             BookReviewLikes bookReviewLikes = BookReviewLikes.create(bookReview, member);
             // 리뷰 저장하기
@@ -59,7 +58,7 @@ public class BookReviewLikeController {
                             .result(true)
                             .status(HttpServletResponse.SC_OK)
                             .data(null)
-                            .message(member.getEmail() + "의 좋아요 완료")
+                            .message(member.getNickname() + "의 좋아요 완료")
                             .build()
             );
         } catch (Exception e) {

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
@@ -13,11 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.ErrorResponse;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name="Book Review Like", description = "책 한 줄 리뷰의 좋아요 관련 기능 api")
@@ -64,6 +60,38 @@ public class BookReviewLikeController {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Operation(summary = "책 한 줄 리뷰에 좋아요 취소", description = "[로그인 필수] 책 리뷰 아이디를 넘겨주어야 합니다!")
+    @DeleteMapping("/booksnap/unlike")
+    public ResponseEntity<?> unlikeBookReview(Authentication authentication, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
+        try{
+            // 멤버 객체랑 북 리뷰 객체 가져오기
+            Member member = (Member) authentication.getPrincipal();
+            Long bookReviewId = bookReviewLikeRequest.getBookReviewId();
+            BookReview bookReview = bookReviewService.getBookReviewById(bookReviewId);
+            // 좋아요 누른 적이 없는데 삭제하려고 하는 경우
+            if(!bookReviewLikeService.isAleadyLiked(bookReview, member)){
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                        member.getNickname()+"님이 좋아요 한 적이 없는 리뷰입니다...😅"
+                );
+            }
+            // 북 리뷰랑 멤버로 좋아요 객체 가져옴
+            BookReviewLikes bookReviewLikes = bookReviewLikeService.getLike(bookReview, member);
+            // 해당 좋아요 객체 삭제
+            bookReviewLikeService.deleteLike(bookReviewLikes);
+            return ResponseEntity.ok(
+                    SuccessResponse.builder()
+                    .result(true)
+                    .status(HttpServletResponse.SC_OK)
+                    .data(null)
+                    .message("리뷰 삭제 성공😊")
+                    .build()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
 }

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
@@ -1,0 +1,70 @@
+package com.capstone.bszip.Book.controller;
+
+import com.capstone.bszip.Book.domain.BookReview;
+import com.capstone.bszip.Book.domain.BookReviewLikes;
+import com.capstone.bszip.Book.dto.BookReviewLikeRequest;
+import com.capstone.bszip.Book.dto.BookSearchResponse;
+import com.capstone.bszip.Book.service.BookReviewLikeService;
+import com.capstone.bszip.Book.service.BookReviewService;
+import com.capstone.bszip.Member.domain.Member;
+import com.capstone.bszip.commonDto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name="Book Review Like", description = "책 한 줄 리뷰의 좋아요 관련 기능 api")
+@RequestMapping("/api")
+public class BookReviewLikeController {
+    private final BookReviewLikeService bookReviewLikeService;
+    private final BookReviewService bookReviewService;
+
+    public BookReviewLikeController(BookReviewLikeService bookReviewLikeService, BookReviewService bookReviewService) {
+        this.bookReviewLikeService = bookReviewLikeService;
+        this.bookReviewService = bookReviewService;
+    }
+
+    /*
+    * 책 리뷰에 좋아요 누르기 (로그인 필수)
+    * */
+    @Operation(summary = "책 한 줄 리뷰에 좋아요", description = "[로그인 필수] 책 리뷰 아이디를 넘겨주어야 합니다!")
+    @PostMapping("/booksnap/like")
+    public ResponseEntity<?> likeBookReview(Authentication authentication, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
+
+        try{
+            // 멤버 가지고 오기
+            Member member = (Member) authentication.getPrincipal();
+            // 해당 책 한 줄 리뷰 가지고 오기
+            //[추가] 유저가 이미 좋아요한 것인지도 판단헤주면 좋을 듯!!
+            Long bookReviewId = bookReviewLikeRequest.getBookReviewId();
+            BookReview bookReview = bookReviewService.getBookReviewById(bookReviewId);
+
+            // 좋아요 객체 만들기
+            BookReviewLikes bookReviewLikes = BookReviewLikes.create(bookReview, member);
+            // 리뷰 저장하기
+            bookReviewLikeService.saveLike(bookReviewLikes);
+            return ResponseEntity.ok(
+                    SuccessResponse.builder()
+                            .result(true)
+                            .status(HttpServletResponse.SC_OK)
+                            .data(null)
+                            .message(member.getEmail() + "의 좋아요 완료")
+                            .build()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/Book/domain/BookReview.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/BookReview.java
@@ -3,15 +3,21 @@ package com.capstone.bszip.Book.domain;
 import com.capstone.bszip.Member.domain.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@ToString(exclude = {"bookReviewLikesList"})
 @Table(name="BookReview")
 public class BookReview {
     @Id
@@ -40,6 +46,9 @@ public class BookReview {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "bookReview", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookReviewLikes> bookReviewLikesList = new ArrayList<>();
 
     public BookReview(String bookReviewText, int bookRating, Book book, Member member) {
         this.bookReviewText = bookReviewText;

--- a/src/main/java/com/capstone/bszip/Book/domain/BookReviewLikes.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/BookReviewLikes.java
@@ -1,0 +1,38 @@
+package com.capstone.bszip.Book.domain;
+
+import com.capstone.bszip.Member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class BookReviewLikes {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private Date createdAt;
+
+    @ManyToOne
+    @JoinColumn(name="bookreview_id")
+    private BookReview bookReview;
+
+    @ManyToOne
+    @JoinColumn(name="member_id")
+    private Member member;
+
+    // 정적 팩토리 메서드로 객체 생성
+    public static BookReviewLikes create(BookReview bookReview, Member member) {
+        BookReviewLikes bookReviewLikes = new BookReviewLikes();
+        bookReviewLikes.bookReview = bookReview;
+        bookReviewLikes.member = member;
+        return bookReviewLikes;
+    }
+}

--- a/src/main/java/com/capstone/bszip/Book/dto/BookReviewLikeRequest.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/BookReviewLikeRequest.java
@@ -1,0 +1,8 @@
+package com.capstone.bszip.Book.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BookReviewLikeRequest {
+    private Long bookReviewId;
+}

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.bszip.Book.repository;
+
+import com.capstone.bszip.Book.domain.BookReviewLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookReviewLikesRepository extends JpaRepository<BookReviewLikes, Long> {
+}

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -1,9 +1,12 @@
 package com.capstone.bszip.Book.repository;
 
+import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.BookReviewLikes;
+import com.capstone.bszip.Member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BookReviewLikesRepository extends JpaRepository<BookReviewLikes, Long> {
+    boolean existsBookReviewLikesByBookReviewAndMember(BookReview bookReview, Member member);
 }

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -6,7 +6,10 @@ import com.capstone.bszip.Member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BookReviewLikesRepository extends JpaRepository<BookReviewLikes, Long> {
     boolean existsBookReviewLikesByBookReviewAndMember(BookReview bookReview, Member member);
+    Optional<BookReviewLikes> findBookReviewLikesByBookReviewAndMember(BookReview bookReview, Member member);
 }

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
+    Optional<BookReview> findBookReviewByBookReviewId(Long bookReviewId);
 }

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
@@ -35,4 +35,17 @@ public class BookReviewLikeService {
         return bookReviewLikesRepository.existsBookReviewLikesByBookReviewAndMember(bookReview, member);
     }
 
+    public BookReviewLikes getLike(BookReview bookReview, Member member) {
+        return bookReviewLikesRepository.findBookReviewLikesByBookReviewAndMember(bookReview, member).orElseThrow(()-> new EntityNotFoundException("해당 리뷰와 멤버로 리뷰를 찾을 수 없음"));
+    }
+
+    public void deleteLike(BookReviewLikes bookReviewLikes) {
+        try{
+            bookReviewLikesRepository.delete(bookReviewLikes);
+        }catch (Exception e){
+            throw new RuntimeException(e);
+        }
+
+    }
+
 }

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
@@ -1,0 +1,31 @@
+package com.capstone.bszip.Book.service;
+
+import com.capstone.bszip.Book.domain.BookReview;
+import com.capstone.bszip.Book.domain.BookReviewLikes;
+import com.capstone.bszip.Book.repository.BookReviewLikesRepository;
+import com.capstone.bszip.Book.repository.BookReviewRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookReviewLikeService {
+    private BookReviewLikesRepository bookReviewLikesRepository;
+    private BookReviewRepository bookReviewRepository;
+
+    public BookReviewLikeService(BookReviewLikesRepository bookReviewLikesRepository, BookReviewRepository bookReviewRepository) {
+        this.bookReviewLikesRepository = bookReviewLikesRepository;
+        this.bookReviewRepository = bookReviewRepository;
+    }
+
+    public void saveLike(BookReviewLikes bookReviewLikes) {
+        try{
+            bookReviewLikesRepository.save(bookReviewLikes);
+        }catch (DataIntegrityViolationException e){
+            throw new DataIntegrityViolationException("무결성 제약 조건 위반: ", e);
+        } catch (Exception e){
+            throw new RuntimeException("알수 없는 에러");
+        }
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewLikeService.java
@@ -4,7 +4,9 @@ import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.BookReviewLikes;
 import com.capstone.bszip.Book.repository.BookReviewLikesRepository;
 import com.capstone.bszip.Book.repository.BookReviewRepository;
+import com.capstone.bszip.Member.domain.Member;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +28,11 @@ public class BookReviewLikeService {
         } catch (Exception e){
             throw new RuntimeException("알수 없는 에러");
         }
+    }
+
+
+    public boolean isAleadyLiked(BookReview bookReview, Member member) {
+        return bookReviewLikesRepository.existsBookReviewLikesByBookReviewAndMember(bookReview, member);
     }
 
 }

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
@@ -10,13 +10,19 @@ import com.capstone.bszip.Book.repository.BookReviewRepository;
 import com.capstone.bszip.Member.domain.Member;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.*;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -119,11 +125,6 @@ public class BookReviewService {
         }
     }
 
-    /*
-    * 지금 문제 query만 생각해서 제목이나 작가로 검색할 때 query가 같아도 증가됨...
-    * 그리고 지금은 유저가 한명이지만,, 여러명의 유저가 같은 걸 검색하면 어카냐...
-    * 그냥 url을 [더보기]랑 / [처음 검색]이랑 분리하는 게 나을 듯....
-    * */
 
     // 역직렬화 - Jackson
     public AddIsEndBookResponse convertToBookSearchResponse(String bookJson){
@@ -245,5 +246,8 @@ public class BookReviewService {
 
     }
 
+    public BookReview getBookReviewById(Long bookReviewId) {
+        return bookReviewRepository.findBookReviewByBookReviewId(bookReviewId).orElseThrow(()-> new EntityNotFoundException("BookReview not found : "+ bookReviewId));
+    }
 
 }

--- a/src/main/java/com/capstone/bszip/Member/domain/Member.java
+++ b/src/main/java/com/capstone/bszip/Member/domain/Member.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @Entity
 @Data
 @EntityListeners(AuditingEntityListener.class)
-@ToString(exclude = {"bookReviews"})
+@ToString(exclude = {"bookReviews", "bookReviewLikes"})
 @Table(name = "members") // 테이블 이름 매핑
 public class Member {
     @Id
@@ -58,4 +58,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookReview> bookReviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookReview> bookReviewLikes = new ArrayList<>();
 }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 책 한 줄 리뷰에서 좋아요하는 기능을 구현했습니다.
  - 로그인 후, 책 리뷰 아이디를 보내주면 좋아요할 수 있습니다.
  - 해당 회원이 이미 좋아요를 한 경우에는 이미 좋아요 했다는 내용이 나오게 됩니다. 
  - 책 리뷰 좋아요에 대해서 정적 팩토리 메소드를 이용해서 생성할 수 있게 했습니다...
    - 빌드 패턴은 필드의 개수가 많은 경우에 많이 쓰고, 필드의 개수가 4개 이하인 경우에는 생성자나 정적 팩토리 메서드를 이용한다고 합니다...!
    - 좋아요 같은 경우에는 id, 책, 회원, 생성시간으로 필드의 개수가 적기 때문에 정적 팩토리 메서드를 이용해보았습니닷😊
    - 근데 제가 이미 많은 걸 생성자로 해버려서 시간이 있으면 빌드패턴으로 변경하려구요😅
 - 로그인 후, 책 리뷰 아이디를 보내주면 좋아요를 취소할 수 있습니다!

- 엄청 간단해서 재밌었습니당 ㅎ..ㅎ

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/756b00ac-b86b-4cd8-b784-3fdc57e5d8aa)




<br/>

## 🔧 앞으로의 과제

- 좋아요 취소 api
- 책 리뷰 최신순 보이기 api(pageable 이용!!)

  <br/>

## ➕ 이슈 링크

- [Backend #22](https://github.com/TEAM-ZIP/Backend/issues/22#issue-2840801056)

<br/>
