### PR TITLE
update(#1): 멤버 엔티티에 tempPassword 추가

### DIFF
--- a/src/main/java/com/capstone/bszip/Member/controller/PasswordManagementController.java
+++ b/src/main/java/com/capstone/bszip/Member/controller/PasswordManagementController.java
@@ -1,5 +1,6 @@
 package com.capstone.bszip.Member.controller;
 
+import com.capstone.bszip.Member.service.MemberService;
 import com.capstone.bszip.Member.service.PasswordManagementService;
 import com.capstone.bszip.Member.service.dto.EmailMessage;
 import com.capstone.bszip.Member.service.dto.EmailRequest;
@@ -27,8 +28,11 @@ import org.springframework.web.client.HttpClientErrorException;
 @Tag(name="TempPassword", description = "임시 비밀번호")
 public class PasswordManagementController {
     private final PasswordManagementService passwordManagementService;
-    public PasswordManagementController(PasswordManagementService passwordManagementService) {
+    private final MemberService memberService;
+
+    public PasswordManagementController(PasswordManagementService passwordManagementService, MemberService memberService) {
         this.passwordManagementService = passwordManagementService;
+        this.memberService = memberService;
     }
     @Operation(summary = "임시 비밀번호 재설정 및 메일 전송")
     @ApiResponses({
@@ -47,6 +51,7 @@ public class PasswordManagementController {
                     .subject("[서점ZIP] 임시 비밀번호 발급")
                     .build();
             passwordManagementService.sendMail(emailMessage, "password");
+            memberService.setTempPassword(emailRequest.getEmail());
 
             return ResponseEntity.ok(
                     SuccessResponse.builder()

--- a/src/main/java/com/capstone/bszip/Member/domain/Member.java
+++ b/src/main/java/com/capstone/bszip/Member/domain/Member.java
@@ -39,8 +39,8 @@ public class Member {
     @Column(name = "join_type",nullable = false)
     private MemberJoinType memberJoinType;
 
-    @Column(name = "social_id")
-    private String socialId;
+    @Column(name = "temp_password", nullable = false)
+    private int tempPassword; // 0이면 사용자가 입력한 비밀번호고, 1이면 임시비밀번호임
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/com/capstone/bszip/Member/service/MemberService.java
+++ b/src/main/java/com/capstone/bszip/Member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.capstone.bszip.auth.refreshToken.RefreshTokenRepository;
 import com.capstone.bszip.auth.security.JwtUtil;
 import com.capstone.bszip.Member.service.dto.LoginRequest;
 import com.capstone.bszip.Member.service.dto.SignupRequest;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -65,6 +66,7 @@ public class MemberService {
         member.setCreatedAt(LocalDateTime.now());
         member.setUpdatedAt(LocalDateTime.now());
         member.setNickname(nickname);
+        member.setTempPassword(0);
         if(password.equals("kakao-password")){
             member.setMemberJoinType(MemberJoinType.KAKAO);
         } else {
@@ -123,6 +125,17 @@ public class MemberService {
 
     public void showAllMembers(){
         memberRepository.findAll().forEach(System.out::println);
+    }
+
+    public void setTempPassword(String email){
+        try{
+            Member member = memberRepository.findByEmail(email).orElseThrow(()-> new EntityNotFoundException("Member Not Found"));
+            member.setTempPassword(1);
+            memberRepository.save(member);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
 }
 


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 멤버테이블에 tempPassword attribute 추가
  - **0이면 사용자가 설정한 비밀번호이고 1이면 임시 비밀번호**라는 뜻!!
  - 임시비밀번호 설정한 경우, 1로 바꾸도록 수정했음
  - 이후에 임시비밀번호인지 아닌지 알려주는 api 만들면 될듯??


  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/fad15c45-45d5-43e0-8b4e-4c2cc4f6bfbd)



<br/>

## 🔧 앞으로의 과제



  <br/>

## ➕ 이슈 링크

- [Backed #1](https://github.com/TEAM-ZIP/Backend/issues/1#issue-2798815625)

<br/>
