### PR TITLE
fix(#23) : bookstore 필드 추가 및 반환 정보 변경

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -3,6 +3,7 @@ package com.capstone.bszip.Bookstore.controller;
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.service.BookstoreService;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,7 +45,7 @@ public class BookstoreController {
     @GetMapping("/search")
     public ResponseEntity<?> searchBookstores(@RequestParam String keyword) {
         try {
-            List<Bookstore> bookstores = bookstoreService.searchBookstores(keyword);
+            List<BookstoreResponse> bookstores = bookstoreService.searchBookstores(keyword);
             if (bookstores.isEmpty()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body("검색어에 해당하는 서점이 없습니다.");
@@ -72,7 +73,7 @@ public class BookstoreController {
     public ResponseEntity<?> getBookstoresByCategory(
             @Parameter(description = "조회할 서점 카테고리 (선택사항)") @RequestParam(required = false) BookstoreCategory category){
         try{
-            List<Bookstore> bookstores = bookstoreService.getBookstoresByCategory(category);
+            List<BookstoreResponse> bookstores = bookstoreService.getBookstoresByCategory(category);
             return ResponseEntity.ok(bookstores);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
@@ -31,4 +31,7 @@ public class Bookstore {
     @Column(name = "description")
     private String description;
 
+    @Column(name="rating")
+    private Double rating;
+
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -3,27 +3,48 @@ package com.capstone.bszip.Bookstore.service;
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class BookstoreService {
     private final BookstoreRepository bookstoreRepository;
     @Transactional
-    public List<Bookstore> searchBookstores(String keyword) {
-        return bookstoreRepository.findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(keyword,keyword);
+    public List<BookstoreResponse> searchBookstores(String keyword) {
+        List<Bookstore> bookstores = bookstoreRepository.findByNameContainingIgnoreCaseOrAddressContainingIgnoreCase(keyword, keyword);
+
+        return bookstores.stream()
+                .map(this::convertToBookstoreResponse)
+                .collect(Collectors.toList());
     }
 
     @Transactional
-    public List<Bookstore> getBookstoresByCategory(BookstoreCategory category){
+    public List<BookstoreResponse> getBookstoresByCategory(BookstoreCategory category){
         if(category == null){
-            return bookstoreRepository.findAll();
+            List <Bookstore> bookstores = bookstoreRepository.findAll();
+            return bookstores.stream()
+                    .map(this::convertToBookstoreResponse)
+                    .collect(Collectors.toList());
         }
-        return bookstoreRepository.findByBookstoreCategory(category);
+        List <Bookstore> bookstores =bookstoreRepository.findByBookstoreCategory(category);
+        return bookstores.stream()
+                .map(this::convertToBookstoreResponse)
+                .collect(Collectors.toList());
+    }
+
+    private BookstoreResponse convertToBookstoreResponse (Bookstore bookstore){
+        return new BookstoreResponse(
+                bookstore.getName(),
+                bookstore.getRating(),
+                bookstore.getBookstoreCategory(),
+                bookstore.getAddress()
+        );
     }
 
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.capstone.bszip.Bookstore.domain.BookstoreCategory.CHILD;
+
 @Service
 @RequiredArgsConstructor
 public class BookstoreService {
@@ -39,11 +41,15 @@ public class BookstoreService {
     }
 
     private BookstoreResponse convertToBookstoreResponse (Bookstore bookstore){
+        String addressExceptCode = bookstore.getAddress();
+        if(bookstore.getBookstoreCategory()!=CHILD) {
+            addressExceptCode =addressExceptCode.substring(8);
+        }
         return new BookstoreResponse(
                 bookstore.getName(),
                 bookstore.getRating(),
                 bookstore.getBookstoreCategory(),
-                bookstore.getAddress()
+                addressExceptCode
         );
     }
 

--- a/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/OpenApiService.java
@@ -2,6 +2,7 @@ package com.capstone.bszip.Bookstore.service;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,7 @@ public class OpenApiService {
             bookstore.setHours((String) item.get("DESCRIPTION"));
             bookstore.setAddress((String) item.get("ADDRESS"));
             bookstore.setDescription((String) item.get("SUB_DESCRIPTION"));
+            bookstore.setRating(0.0);//초기화
             bookstoreRepository.save(bookstore);
         }
     }
@@ -79,6 +81,7 @@ public class OpenApiService {
             bookstore.setHours((String) item.get("DESCRIPTION"));
             bookstore.setAddress((String) item.get("ADDRESS"));
             bookstore.setDescription((String) item.get("SUB_DESCRIPTION"));
+            bookstore.setRating(0.0);//초기화
             bookstoreRepository.save(bookstore);
         }
     }
@@ -107,6 +110,7 @@ public class OpenApiService {
                     + "일요일개점마감시간" + convertDecimalToTime(item.get("SUN_OPN_BSNS_TIME")) + "~" + convertDecimalToTime(item.get("SUN_CLOS_TIME")));
             bookstore.setAddress((String) item.get("FCLTY_ROAD_NM_ADDR"));
             bookstore.setDescription((String) item.get("ADIT_DC"));
+            bookstore.setRating(0.0);//초기화
             bookstoreRepository.save(bookstore);
         }
     }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreResponse.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreResponse.java
@@ -1,14 +1,15 @@
 package com.capstone.bszip.Bookstore.service.dto;
 
+import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class BookstoreResponse {
     private String name;
-    //private double rating; 별점 _ 리뷰 후에
-    private String category;
-    private String phone;
-    private String hours;
+    private double rating;
+    private BookstoreCategory bookstoreCategory;
     private String address;
-    private String description;
+
 }


### PR DESCRIPTION

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- bookstore에 별점 필드 추가했고 리뷰 추가, 수정, 삭제될 때마다 평균 별점 업데이트로 변경할 예정입니닷 
(별점 가져올때마다 서점 리뷰 db값을 읽어오는게 더 비효율인거 같아서 💦 아예 필드로 계산해서 저장하는게 나을듯)
* api request 시 0.0으로 초기화되도록 했음

- 서점 결과 반환시 리스트에 보여지는 이름, 별점, 카테고리, 주소만 골라 반환하도록 변경

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/2e2468b0-a53a-454d-9e86-f731204f3766)
rating 추가

![image](https://github.com/user-attachments/assets/72d65bb9-9687-46c8-a7e8-3a2fc29b3866)
필요한 필드만 반환하도록 변경했습니닷


<br/>

## 🔧 앞으로의 과제

- 내가 찜한 서점 !!

  <br/>

## ➕ 이슈 링크

- [Backend #23](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
