### PR TITLE
update(#23): 찜한 서점 리스트 totalCnt,카테고리 필터링 추가 

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -177,6 +177,7 @@ public class BookstoreController {
     })
     @GetMapping("/liked")
     public ResponseEntity<?> getLikedBookstores(
+            @RequestParam(required = false) BookstoreCategory category,
             @Parameter(hidden = true) @AuthenticationPrincipal Member member
     ) {
         if (member == null) {
@@ -189,8 +190,13 @@ public class BookstoreController {
                             .build());
         }
         try{
-            List<BookstoreResponse> likedBookstores = bookstoreService.getLikedBookstores(member);
-
+            List<BookstoreResponse> likedBookstores;
+            if(category == null){
+                likedBookstores = bookstoreService.getLikedBookstores(member);
+            }
+            else {
+                likedBookstores = bookstoreService.getLikedBookstoresByCategory(member, category);
+            }
             Map<String, Object> responseData = new HashMap<>();
             responseData.put("totalCnt", likedBookstores.size());
             responseData.put("bookstores", likedBookstores);

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -22,7 +22,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @RestController
@@ -188,11 +190,16 @@ public class BookstoreController {
         }
         try{
             List<BookstoreResponse> likedBookstores = bookstoreService.getLikedBookstores(member);
-            return ResponseEntity.ok(SuccessResponse.<List<BookstoreResponse>>builder()
+
+            Map<String, Object> responseData = new HashMap<>();
+            responseData.put("totalCnt", likedBookstores.size());
+            responseData.put("bookstores", likedBookstores);
+
+            return ResponseEntity.ok(SuccessResponse.<Map<String, Object>>builder()
                     .result(true)
                     .status(HttpStatus.OK.value())
                     .message("찜한 서점 목록 조회 성공")
-                    .data(likedBookstores)
+                    .data(responseData)
                     .build());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -102,4 +102,20 @@ public class BookstoreService {
 
     }
 
+    @Transactional
+    public List<BookstoreResponse> getLikedBookstoresByCategory(Member member,BookstoreCategory category){
+        String memberKey = "member:liked:bookstores:" + member.getMemberId();
+        Set<String> bookstoreIds = redisTemplate.opsForSet().members(memberKey);
+
+        List<Long> longBookstoreIds = bookstoreIds.stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+        List <Bookstore> bookstores = bookstoreRepository.findAllById(longBookstoreIds);
+
+        return bookstores.stream()
+                .filter(bookstore -> bookstore.getBookstoreCategory()==category)
+                .map(Bookstore -> convertToBookstoreResponse(Bookstore,member))
+                .collect(Collectors.toList());
+
+    }
 }


### PR DESCRIPTION

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용
- 찜한 서점 수 totalCnt 반환
- 찜한 서점 리스트 - default로 전체 리스트, 카테고리별로 필터링 추가 


  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/ed420d14-a487-43b4-8a07-ea8347960a4d)
![image](https://github.com/user-attachments/assets/2a64e441-b0b4-47c7-a81a-8ab8518346da)


<br/>

## 🔧 앞으로의 과제



  <br/>

## ➕ 이슈 링크

- [Backend #23 ](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
