### PR TITLE
feat(#22): 요즘 인기 있는 순 구현 및 get review 쿼리로 통합

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -340,16 +339,15 @@ public class BookReviewController {
                             "}"
             )})),})
     @GetMapping("/reviews")
-    public ResponseEntity<?> getRecentReviews(@RequestParam(required = false) String srt,
-            @PageableDefault(size = 10,sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<?> getRecentReviews(@RequestParam(required = true) ReviewSort sort,
+                                              @PageableDefault(size = 10,sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                               @AuthenticationPrincipal Member member) {
         try{
-            System.out.println(srt);
             Page<BooksnapPreviewDto> bookReviews = null;
-            if(srt.equals("recent")){
+            if(sort.equals(ReviewSort.createdAt)){
                 bookReviews = bookReviewService.getRecentReviews(pageable, member);
-            } else if(srt.equals("like-top") || srt.equals("trend")){
-                bookReviews = bookReviewService.getLikeTopReviews(pageable, member, srt);
+            } else if(sort.equals(ReviewSort.liketop) || sort.equals(ReviewSort.trend)){
+                bookReviews = bookReviewService.getLikeTopReviews(pageable, member, sort);
             }
 
             BooksnapPreviewResponse booksnapPreviewResponse = BooksnapPreviewResponse.builder()
@@ -362,7 +360,7 @@ public class BookReviewController {
                     SuccessResponse.builder()
                             .result(true)
                             .status(HttpServletResponse.SC_OK)
-                            .message(srt + " 기준 리뷰 🥐")
+                            .message(sort + " 기준 리뷰 🥐")
                             .data(booksnapPreviewResponse)
                             .build()
             );

--- a/src/main/java/com/capstone/bszip/Book/dto/ReviewSort.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/ReviewSort.java
@@ -1,0 +1,5 @@
+package com.capstone.bszip.Book.dto;
+
+public enum ReviewSort {
+    createdAt, liketop, trend;
+}

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -3,12 +3,14 @@ package com.capstone.bszip.Book.repository;
 import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.BookReviewLikes;
 import com.capstone.bszip.Member.domain.Member;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,4 +26,11 @@ public interface BookReviewLikesRepository extends JpaRepository<BookReviewLikes
     List<Object[]> countBookReviewLikeForAllReviews();
 
     int countByBookReview_BookReviewId(long bookReviewId);
+
+    @Query("SELECT br1.bookReview.bookReviewId, COUNT(br1) "+
+    "FROM BookReviewLikes br1 " +
+    "WHERE br1.createdAt >= :sevenDaysAgo " +
+    "GROUP BY br1.bookReview.bookReviewId " +
+    "ORDER BY COUNT (br1) DESC ")
+    List<Object[]> countBookReviewLikeForLast7Days(@Param("sevenDaysAgo")LocalDateTime sevenDaysAgo);
 }

--- a/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
+++ b/src/main/java/com/capstone/bszip/Book/service/BookReviewService.java
@@ -327,13 +327,13 @@ public class BookReviewService {
                 );
     }
 
-    public Page<BooksnapPreviewDto> getLikeTopReviews(Pageable pageable, Member member, String sort){
+    public Page<BooksnapPreviewDto> getLikeTopReviews(Pageable pageable, Member member, ReviewSort sort){
         long start = (long) pageable.getPageNumber() * pageable.getPageSize();
         long end = start + pageable.getPageSize() - 1;
         String key = null;
-        if(sort.equals("like-top")){
+        if(sort.equals(ReviewSort.liketop)){
             key = BOOK_REVIEW_LIKES_KEY;
-        } else if (sort.equals("trend")) {
+        } else if (sort.equals(ReviewSort.trend)) {
             key = LAST7DAYS_BOOK_REVIEW_LIKES_KEY;
         }
         // Redis에서 좋아요 개수가 많은 리뷰 ID 목록 가져오기

--- a/src/main/java/com/capstone/bszip/Book/service/RedisInitializer.java
+++ b/src/main/java/com/capstone/bszip/Book/service/RedisInitializer.java
@@ -4,22 +4,27 @@ import com.capstone.bszip.Book.repository.BookReviewLikesRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@EnableScheduling
 public class RedisInitializer {
     private final RedisTemplate<String, Object> redisTemplate;
     private final BookReviewLikesRepository bookReviewLikesRepository;
 
     private static final String BOOK_REVIEW_LIKES_KEY = "book_review_likes:";
+    private static final String LAST7DAYS_BOOK_REVIEW_LIKES_KEY = "last7days_book_review_likes:";
 
     @PostConstruct
     public void loadBookReviewLikes() {
-        System.out.println("🔹 RedisInitializer 실행 중...");
+        System.out.println("🔹 BookReviewLikes - RedisInitializer 실행 중...");
 
         List<Object[]> likeCounts = bookReviewLikesRepository.countBookReviewLikeForAllReviews();
         for (Object[] row : likeCounts) {
@@ -33,5 +38,23 @@ public class RedisInitializer {
             System.out.println("✅ Redis 저장: reviewId=" + reviewId + ", likeCount=" + likeCount);
         }
 
+    }
+
+    @PostConstruct
+    @Scheduled(cron="0 0 0 * * ?")
+    public void getLikesForBookReviewFromLast7Days(){
+        // 오늘(실시간)부터 7일 전의 생성된 좋아요 데이터를 가지고 좋아요 순으로 ZSet에 저장
+        System.out.println("🥦 BookReviewFromLast7Days - redisinitializer 실행 중 ...");
+
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        List<Object []> likeCounts = bookReviewLikesRepository.countBookReviewLikeForLast7Days(sevenDaysAgo);
+        for (Object[] row : likeCounts) {
+            Long reviewId = (Long) row[0];
+            Long likeCount = (Long) row[1];
+
+            redisTemplate.opsForZSet().add(LAST7DAYS_BOOK_REVIEW_LIKES_KEY, reviewId.toString(), likeCount);
+
+            System.out.println("🥦 Redis 저장 : reviewId=" + reviewId + ", likeCount=" + likeCount);
+        }
     }
 }

--- a/src/main/java/com/capstone/bszip/BszipApplication.java
+++ b/src/main/java/com/capstone/bszip/BszipApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
+@EnableScheduling
 public class BszipApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 📈**요즘 인기 있는 순 구현**
  - postconstruct를 이용해 서버 시작 시 한 번, Schenduled와 cron으로 매일 정각에 한 번 Redis ZSet에 값 입력 받음
  - 데이터 삭제로 인하여 기존 전체 좋아요 수 관련 ZSet과 다르게 키 설정함
  - 좋아요 추가/삭제 시 메인 DB에 등록 + Redis 등록

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/e7f67279-d005-4309-abca-60def4582ee3)



<br/>

## 🔧 앞으로의 과제

- 진짜 부키 ㄱㄱ

  <br/>

## ➕ 이슈 링크

- [Backend #22 ](https://github.com/TEAM-ZIP/Backend/issues/22#issue-2840801056)

<br/>
