### PR TITLE
fix(#22): like top review

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
@@ -123,7 +123,8 @@ public class BookReviewLikeController {
             // 북 리뷰랑 멤버로 좋아요 객체 가져옴
             BookReviewLikes bookReviewLikes = bookReviewLikeService.getLike(bookReview, member);
             // 해당 좋아요 객체 삭제
-            bookReviewLikeService.deleteLike(bookReviewLikes);
+            boolean isLikedFromlast7days = bookReviewLikeService.isLikedFromLast7Days(bookReviewLikes.getCreatedAt());
+            bookReviewLikeService.deleteLike(bookReviewLikes, isLikedFromlast7days);
             return ResponseEntity.ok(
                     SuccessResponse.builder()
                     .result(true)

--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewLikeController.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -33,11 +34,10 @@ public class BookReviewLikeController {
     * */
     @Operation(summary = "책 한 줄 리뷰에 좋아요", description = "[로그인 필수] 책 리뷰 아이디를 넘겨주어야 합니다!")
     @PostMapping("/booksnap/like")
-    public ResponseEntity<?> likeBookReview(Authentication authentication, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
+    public ResponseEntity<?> likeBookReview(@AuthenticationPrincipal Member member, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
 
         try{
             // 멤버 가지고 오기
-            Member member = (Member) authentication.getPrincipal();
             if(member == null){
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
                         ErrorResponse.builder()
@@ -61,7 +61,11 @@ public class BookReviewLikeController {
 
             if(bookReviewLikeService.isAleadyLiked(bookReview, member)){
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                        member.getNickname()+"님이 이미 좋아요하셨습니다...😅"
+                        ErrorResponse.builder()
+                                        .result(false)
+                                        .message(member.getNickname()+"님이 이미 좋아요하셨습니다...😅")
+                                        .build()
+
                 );
             }
             // 좋아요 객체 만들기
@@ -92,10 +96,9 @@ public class BookReviewLikeController {
 
     @Operation(summary = "책 한 줄 리뷰에 좋아요 취소", description = "[로그인 필수] 책 리뷰 아이디를 넘겨주어야 합니다!")
     @DeleteMapping("/booksnap/unlike")
-    public ResponseEntity<?> unlikeBookReview(Authentication authentication, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
+    public ResponseEntity<?> unlikeBookReview(@AuthenticationPrincipal Member member, @RequestBody BookReviewLikeRequest bookReviewLikeRequest){
         try{
             // 멤버 객체랑 북 리뷰 객체 가져오기
-            Member member = (Member) authentication.getPrincipal();
             if(member == null){
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
                         ErrorResponse.builder()
@@ -110,7 +113,11 @@ public class BookReviewLikeController {
             // 좋아요 누른 적이 없는데 삭제하려고 하는 경우
             if(!bookReviewLikeService.isAleadyLiked(bookReview, member)){
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                        member.getNickname()+"님이 좋아요 한 적이 없는 리뷰입니다...😅"
+                        ErrorResponse.builder()
+                                .result(false)
+                                .message(member.getNickname()+"님이 좋아요 한 적이 없는 리뷰입니다...😅")
+                                .build()
+
                 );
             }
             // 북 리뷰랑 멤버로 좋아요 객체 가져옴

--- a/src/main/java/com/capstone/bszip/Book/domain/BookReviewLikes.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/BookReviewLikes.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -18,7 +19,7 @@ public class BookReviewLikes {
     private Long id;
 
     @CreatedDate
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
     @ManyToOne
     @JoinColumn(name="bookreview_id")

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -4,6 +4,7 @@ import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.BookReviewLikes;
 import com.capstone.bszip.Member.domain.Member;
 import io.lettuce.core.dynamic.annotation.Param;
+import net.bytebuddy.asm.Advice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewLikesRepository.java
@@ -27,9 +27,9 @@ public interface BookReviewLikesRepository extends JpaRepository<BookReviewLikes
 
     int countByBookReview_BookReviewId(long bookReviewId);
 
-    @Query("SELECT br1.bookReview.bookReviewId, COUNT(br1) "+
+    @Query("SELECT br1.bookReview.bookReviewId, COUNT(br1)"+
     "FROM BookReviewLikes br1 " +
-    "WHERE br1.createdAt >= :sevenDaysAgo " +
+    "WHERE br1.bookReview.createdAt >= :sevenDaysAgo " +
     "GROUP BY br1.bookReview.bookReviewId " +
     "ORDER BY COUNT (br1) DESC ")
     List<Object[]> countBookReviewLikeForLast7Days(@Param("sevenDaysAgo")LocalDateTime sevenDaysAgo);

--- a/src/main/java/com/capstone/bszip/Book/repository/BookReviewRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/BookReviewRepository.java
@@ -25,4 +25,8 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
 
     @Query("SELECT br.bookReviewId FROM BookReview br")
     List<Long> findAllBookReviewIds();
+
+    @Query("SELECT br.bookReviewId as id, COUNT(bl) as likeCount, br.createdAt FROM BookReview br " +
+            "LEFT JOIN br.bookReviewLikesList bl GROUP BY br.bookReviewId")
+    List<Object[]> getIdAndBookLikeAndCreatedAtFromAllBookReviews();
 }

--- a/src/main/java/com/capstone/bszip/Book/service/RedisInitializer.java
+++ b/src/main/java/com/capstone/bszip/Book/service/RedisInitializer.java
@@ -1,16 +1,19 @@
 package com.capstone.bszip.Book.service;
 
 import com.capstone.bszip.Book.repository.BookReviewLikesRepository;
+import com.capstone.bszip.Book.repository.BookReviewRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -21,40 +24,56 @@ public class RedisInitializer {
 
     private static final String BOOK_REVIEW_LIKES_KEY = "book_review_likes:";
     private static final String LAST7DAYS_BOOK_REVIEW_LIKES_KEY = "last7days_book_review_likes:";
+    private static final String LAST7DAYS_BOOK_REVIEW_ID_KEY = "last7days_book_review_id_";
+    private static final int LAST_7DAYS_WEIGHT = 1000;
+    private final BookReviewRepository bookReviewRepository;
 
     @PostConstruct
+    public void init() {
+        loadBookReviewLikes();
+        getLikesForBookReviewFromLast7Days();
+    }
+
+
     public void loadBookReviewLikes() {
         System.out.println("🔹 BookReviewLikes - RedisInitializer 실행 중...");
 
-        List<Object[]> likeCounts = bookReviewLikesRepository.countBookReviewLikeForAllReviews();
-        for (Object[] row : likeCounts) {
-            Long reviewId = (Long) row[0];
-            Long likeCount = (Long) row[1];
-
+        List<Object[]> likeCounts = bookReviewRepository.getIdAndBookLikeAndCreatedAtFromAllBookReviews();
+        for(Object[] row : likeCounts) {
+            long reviewId = (Long) row[0];
+            long likeCount = (long) row[1];
+            double createdAt = ( (LocalDateTime ) row[2] ).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() / 1_000_000_000_000_0.0;
             // Redis에 저장
-            redisTemplate.opsForZSet().add(BOOK_REVIEW_LIKES_KEY, reviewId.toString(), likeCount);
-
+            redisTemplate.opsForZSet().add(BOOK_REVIEW_LIKES_KEY, Long.toString(reviewId), likeCount + createdAt);
             // 콘솔 출력
             System.out.println("✅ Redis 저장: reviewId=" + reviewId + ", likeCount=" + likeCount);
         }
 
     }
 
-    @PostConstruct
+
     @Scheduled(cron="0 0 0 * * ?")
     public void getLikesForBookReviewFromLast7Days(){
         // 오늘(실시간)부터 7일 전의 생성된 좋아요 데이터를 가지고 좋아요 순으로 ZSet에 저장
         System.out.println("🥦 BookReviewFromLast7Days - redisinitializer 실행 중 ...");
-
+        redisTemplate.opsForZSet().removeRangeByScore(LAST7DAYS_BOOK_REVIEW_LIKES_KEY, 0, -1);
+        copy2Set(BOOK_REVIEW_LIKES_KEY, LAST7DAYS_BOOK_REVIEW_LIKES_KEY);
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
         List<Object []> likeCounts = bookReviewLikesRepository.countBookReviewLikeForLast7Days(sevenDaysAgo);
         for (Object[] row : likeCounts) {
             Long reviewId = (Long) row[0];
             Long likeCount = (Long) row[1];
-
-            redisTemplate.opsForZSet().add(LAST7DAYS_BOOK_REVIEW_LIKES_KEY, reviewId.toString(), likeCount);
+            redisTemplate.opsForZSet().incrementScore(LAST7DAYS_BOOK_REVIEW_LIKES_KEY, reviewId.toString(), likeCount * LAST_7DAYS_WEIGHT);
 
             System.out.println("🥦 Redis 저장 : reviewId=" + reviewId + ", likeCount=" + likeCount);
+        }
+    }
+
+    public void copy2Set(String fromkey, String tokey) {
+        Set< ZSetOperations.TypedTuple<Object>> data = redisTemplate.opsForZSet().rangeWithScores(fromkey, 0, -1);
+
+        if(data != null && !data.isEmpty()) {
+            redisTemplate.opsForZSet().add(tokey, data);
         }
     }
 }

--- a/src/main/java/com/capstone/bszip/Bookie/service/OpenAIService.java
+++ b/src/main/java/com/capstone/bszip/Bookie/service/OpenAIService.java
@@ -1,0 +1,33 @@
+package com.capstone.bszip.Bookie.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class OpenAIService {
+
+    private final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    @Value("${openai.api.key}")
+    private String API_KEY;
+
+    public String getChatGPT(String prompt){
+        String payload =  String.format("{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":\"%s\"}]}",
+                prompt);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + API_KEY);
+
+        HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                OPENAI_API_URL, HttpMethod.POST, entity, String.class
+        );
+
+        return response.getBody();
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/config/RedisConfig.java
+++ b/src/main/java/com/capstone/bszip/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,5 @@ bookstore.child.key=${BOOKSTORE_CHILD_KEY}
 
 spring.redis.host=${spring.redis.host}
 spring.redis.port=${spring.redis.port}
+
+openai.api.key=${openai.api.key}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

### 👍 liketop ( 좋아요 순 )
- 좋아요 순의 경우 기존에는 ZSet에 좋아요 0인 BookReviewId는 value로 저장하지 않았는데, **좋아요가 0인 bookReview id도 저장**하게 했습니다.
- 기존에는 좋아요를 눌렀을 때, timestamp 값을 더해서 좋아요 수가 같은 경우에 최신의 리뷰가 더 먼저 오게 했는데, 이번에는 **초기에 저장될 때부터 해당 timestamp 값을 더해 놓고** 좋아요를 추가/삭제 시에는 1을 더하거나 빼게 했습니다.
### 📈 trend ( 요즘 인기 있는 순 )
- 가중치를 설정해서 7일 내에 리뷰 좋아요를 눌렀거나 누르면 높은 순위에 있도록 설정했습니다.
- 7일 내에 리뷰 좋아요를 했고 이를 취소하면 해당 가중치만큼 없어지도록 설정했습니다.

또한 page = 2 부터 중복되는 리뷰가 나타나는 문제점도 이제 없습니

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/c8e67465-0485-4f18-8f57-adc5b0327b08)



<br/>

## 🔧 앞으로의 과제

- 부키 임베딩

  <br/>

## ➕ 이슈 링크

- [Backend #22](https://github.com/TEAM-ZIP/Backend/issues/22#issue-2840801056)

<br/>
