### PR TITLE
Fix(#1): 카카오 로그인 dto 수정 및 책 담기 에러코드 수정

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/BookReviewController.java
@@ -135,11 +135,8 @@ public class BookReviewController {
     * - 책 ID, 별점, 리뷰 받아서 저장*/
     @Operation(summary = "책 한 줄 리뷰 등록", description = "isbn, 리뷰 텍스트, 별점을 보내면 책을 저장하고 리뷰를 저장합니다. 예시 응답은 제목과 동일합니다.")
     @PostMapping("/new-review")
-    public ResponseEntity<?> writeBookReview(Authentication authentication, @RequestBody BookReviewRequest bookReviewRequest) {
+    public ResponseEntity<?> writeBookReview(@AuthenticationPrincipal Member member, @RequestBody BookReviewRequest bookReviewRequest) {
         try{
-            Member member = (Member) authentication.getPrincipal(); // 맴버객체 가져옴
-            // 지금 책이 디비에 없으면 저장하기
-
             if(member == null){
                 return ResponseEntity.status(401).body(
                         ErrorResponse.builder()
@@ -202,9 +199,8 @@ public class BookReviewController {
     * */
     @Operation(summary = "책 한 줄 리뷰 삭제", description = "[로그인 필수] 로그인한 사용자가 작성한 책 리뷰의 id를 받아와서 삭제")
     @DeleteMapping("/reviews/{bookReviewId}")
-    public ResponseEntity<?> deleteBookReview(Authentication authentication, @PathVariable Long bookReviewId) {
+    public ResponseEntity<?> deleteBookReview(@AuthenticationPrincipal Member member, @PathVariable Long bookReviewId) {
         try{
-            Member member = (Member) authentication.getPrincipal();
             if(member == null){
                 return ResponseEntity.status(401).body(
                         ErrorResponse.builder()
@@ -252,9 +248,8 @@ public class BookReviewController {
     * */
     @Operation(summary = "책 한 줄 리뷰 수정", description = "[로그인 필수] 로그인한 사용자가 작성한 책 리뷰의 id를 받아와서 수정")
     @PutMapping("/reviews/{bookReviewId}")
-    public ResponseEntity<?> updateBookReview(Authentication authentication, @PathVariable Long bookReviewId, @RequestBody BookReviewUpdateDto bookReviewUpdateDto) {
+    public ResponseEntity<?> updateBookReview(@AuthenticationPrincipal Member member, @PathVariable Long bookReviewId, @RequestBody BookReviewUpdateDto bookReviewUpdateDto) {
         try{
-            Member member = (Member) authentication.getPrincipal();
             if(member == null){
                 return ResponseEntity.status(401).body(
                         ErrorResponse.builder()
@@ -282,14 +277,6 @@ public class BookReviewController {
                             .build()
             );
 
-        }catch (NullPointerException e){
-            return ResponseEntity.status(400).body(
-                    ErrorResponse.builder()
-                            .result(false)
-                            .status(400)
-                            .message("누락된 값 존재")
-                            .build()
-            );
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/capstone/bszip/Book/controller/PickedBookController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/PickedBookController.java
@@ -31,7 +31,13 @@ public class PickedBookController {
     public ResponseEntity<?> createPickedBook(@AuthenticationPrincipal Member member,
                                            @RequestBody PickedBookRequest pickedBookRequest) {
         try{
-            System.out.println(member);
+            if(member == null){
+                return ResponseEntity.status(401).body(
+                        ErrorResponse.builder()
+                                .message("로그인 후 이용해주세요.")
+                                .build()
+                );
+            }
             Long isbn = Long.parseLong(pickedBookRequest.getIsbn());
             Book book = bookReviewService.getBookByIsbn(isbn);
             if (book == null) {

--- a/src/main/java/com/capstone/bszip/Member/controller/KakaoLoginController.java
+++ b/src/main/java/com/capstone/bszip/Member/controller/KakaoLoginController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.Map;
 
@@ -49,11 +50,28 @@ public class KakaoLoginController {
            try{
                TokenResponse tokens = kakaoService.loginUser(kakaoEmail);
 
-               return ResponseEntity.ok(tokens);
+               return ResponseEntity.ok(
+                       SuccessResponse.builder()
+                               .result(true)
+                               .status(200)
+                               .data(tokens)
+                               .build()
+               );
            }catch (BadCredentialsException e) {
                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                        .body(Map.of("error", "잘못된 접근"));
-           }catch(Exception e){
+           }catch (HttpClientErrorException e){
+               return ResponseEntity.status(400)
+                       .body(
+                               ErrorResponse.builder()
+                               .result(false)
+                               .status(400)
+                               .message("카카오 api 오류")
+                                       .detail(e.getMessage())
+                                       .build()
+                       );
+           }
+           catch(Exception e){
                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                        .body(Map.of("message", e.getMessage()));
            }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용
### 카카오 로그인 DTO 수정
* 기존의 카카오 로그인 DTO는 accessToken, refreshToken을 JSON에 바로 보내는 형식이었는데 수정하여서 SucessResponse common Dto로 보낼 수 있게 변경했습니다.
 ### 책 담기 에러코드 수정
* 기존에 책 담기에 대해서 익명 유저가 눌렀을 때 에러코드 처리를 안해둔 상태여서 401 반환할 수 있게 처리했습니다.
* 책 리뷰 작성 / 수정 / 삭제에도 포함시켰습니다.

  <br/>


## 🔧 앞으로의 과제

- 부키 고치기
- 카카오 회원가입 후 바로 로그인 시키기

  <br/>

## ➕ 이슈 링크

- [Backend #1](https://github.com/TEAM-ZIP/Backend/issues/1#issue-2798815625)

<br/>
