### PR TITLE
feat(#22): 책 검색 시 검색어 저장 및 불러오기 api 구현

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
@@ -43,7 +43,15 @@ public class SearchHistoriesController {
                         ErrorResponse.builder().status(401).result(false).message("로그인 후 이용해주세요.").build()
                 );
             }
-
+            if(searchRequest.getSearchWord() == null || searchRequest.getSearchWord().trim().isEmpty()){
+                return ResponseEntity.status(400).body(
+                        ErrorResponse.builder()
+                                .status(400)
+                                .result(false)
+                                .message("검색어를 입력해야합니다.")
+                                .build()
+                );
+            }
             String searchWord = searchRequest.getSearchWord().toUpperCase();
             String searchType = searchRequest.getSearchType().toUpperCase();
 

--- a/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
@@ -1,21 +1,22 @@
 package com.capstone.bszip.Book.controller;
 
-import com.capstone.bszip.Book.dto.SearchDto;
+import com.capstone.bszip.Book.dto.SearchHistoryResponse;
+import com.capstone.bszip.Book.dto.SearchRequest;
 import com.capstone.bszip.Book.service.SearchHistoriesSevice;
 import com.capstone.bszip.Member.domain.Member;
 import com.capstone.bszip.commonDto.ErrorResponse;
 import com.capstone.bszip.commonDto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "검색 기록", description = "검색 기록 관련 API")
 @RestController
@@ -27,7 +28,7 @@ public class SearchHistoriesController {
 
     @Operation(
             summary = "검색어 저장",
-            description = "검색 성공 후 검색어와 검색 타입을 저장합니다. 책리뷰 검색기록은 searchtype을 'BOOKTITLE'로 해주세요."
+            description = "검색 성공 후 검색어와 검색 타입을 저장합니다. 책리뷰 검색기록은 searchtype을 'booktitle'로 해주세요."
     )
     @ApiResponse(responseCode = "200", description = "검색어 저장 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 요청")
@@ -35,7 +36,7 @@ public class SearchHistoriesController {
     @ApiResponse(responseCode = "500", description = "서버 에러 발생")
     @PostMapping("/search-history")
     public ResponseEntity<?> storeSearchHistories(@AuthenticationPrincipal Member member,
-                                                  @Valid @RequestBody SearchDto searchDto) {
+                                                  @Valid @RequestBody SearchRequest searchRequest) {
         try{
             if(member == null){
                 return ResponseEntity.status(401).body(
@@ -43,12 +44,12 @@ public class SearchHistoriesController {
                 );
             }
 
-            String searchWord = searchDto.getSearchWord();
-            String searchType = searchDto.getSearchType();
+            String searchWord = searchRequest.getSearchWord().toUpperCase();
+            String searchType = searchRequest.getSearchType().toUpperCase();
 
-            if(searchType == null || searchWord == null){
+            if(!searchType.equals("BOOKTITLE") && !searchType.equals("AUTHOR")){
                 return ResponseEntity.status(400).body(
-                        ErrorResponse.builder().status(400).result(false).message("검색어와 검색타입을 모두 포함해주세요.").build()
+                        ErrorResponse.builder().status(400).result(false).message("검색타입을 정확히 포함해주세요.").build()
                 );
             }
 
@@ -60,6 +61,75 @@ public class SearchHistoriesController {
         } catch (Exception e) {
             return ResponseEntity.status(500).body(
                     ErrorResponse.builder().result(false).status(500).message("검색어 저장 실패!").build()
+            );
+        }
+    }
+
+    @Operation(
+            summary = "최근 검색어 불러오기",
+            description = "검색 타입과 page, size를 받으면 검색기록 id와 검색어를 반환합니다.. 책리뷰 검색기록은 searchtype을 'booktitle'로 해주세요."
+    )
+    @ApiResponse(responseCode = "200", description = "검색어 불러오기 성공",
+    content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = SuccessResponse.class),
+            examples = @ExampleObject(value = """
+                                {
+                                    "status": 200,
+                                    "result": true,
+                                    "message": "회원 검색 기록 불러오기",
+                                    "data": {
+                                        isEnd: true,
+                                        searchHistory: [
+                                            { id : 1,
+                                              searchWord : "모순"
+                                            },
+                                            { id : 2,
+                                              searchWord : "사람은 무엇으로 사는가"
+                                            }
+                                        ]
+                                }
+                                """)
+    )
+    )
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
+    @ApiResponse(responseCode = "500", description = "서버 에러 발생")
+    @GetMapping("/search-history")
+    public ResponseEntity<?> getSearchHistories(@AuthenticationPrincipal Member member,
+                                                @RequestParam String searchtype,
+                                                @RequestParam(defaultValue = "1") int page,
+                                                @RequestParam(defaultValue = "10") int size) {
+        try{
+            if(member == null){
+                return ResponseEntity.status(401).body(
+                        ErrorResponse.builder()
+                                .message("유저의 검색 기록은 로그인 후 확인할 수 있습니다.")
+                                .result(false)
+                                .status(401)
+                                .build()
+                );
+            }
+            if(!searchtype.equals("booktitle") && !searchtype.equals("author")){
+                return ResponseEntity.status(400).body(
+                  ErrorResponse.builder()
+                          .message("BOOKTITLE 혹은 AUTHOR로 서치 타입을 정확하게 작성해주세요.")
+                          .result(false)
+                          .status(400)
+                          .build()
+                );
+            }
+
+            SearchHistoryResponse searchHistoryResponses= searchHistoriesSevice.getSearchHistories(member, searchtype, page, size);
+            return ResponseEntity.status(200).body(
+                    SuccessResponse.builder().status(200).result(true)
+                            .message("회원 검색 기록 불러오기")
+                            .data(searchHistoryResponses)
+                    .build()
+            );
+        }catch(Exception e){
+            return ResponseEntity.status(500).body(
+                    ErrorResponse.builder().result(false).status(500).message("저장된 최근 검색어 불러오기 실패!"+ e.getMessage()).build()
             );
         }
     }

--- a/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
@@ -82,22 +82,27 @@ public class SearchHistoriesController {
             mediaType = "application/json",
             schema = @Schema(implementation = SuccessResponse.class),
             examples = @ExampleObject(value = """
-                                {
-                                    "status": 200,
-                                    "result": true,
-                                    "message": "회원 검색 기록 불러오기",
-                                    "data": {
-                                        isEnd: true,
-                                        searchHistory: [
-                                            { id : 1,
-                                              searchWord : "모순"
-                                            },
-                                            { id : 2,
-                                              searchWord : "사람은 무엇으로 사는가"
-                                            }
-                                        ]
-                                }
-                                """)
+                        {
+                            "status": 200,
+                            "result": true,
+                            "message": "회원 검색 기록 불러오기",
+                            "data": {
+                                "isEnd": true,
+                                "totalElements": 5,
+                                "totalPages": 1,
+                                "searchHistory": [
+                                    {
+                                        "id": 1,
+                                        "searchWord": "모순"
+                                    },
+                                    {
+                                        "id": 2,
+                                        "searchWord": "사람은 무엇으로 사는가"
+                                    }
+                                ]
+                            }
+                        }
+                        """)
     )
     )
     @ApiResponse(responseCode = "400", description = "잘못된 요청")

--- a/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
+++ b/src/main/java/com/capstone/bszip/Book/controller/SearchHistoriesController.java
@@ -1,0 +1,67 @@
+package com.capstone.bszip.Book.controller;
+
+import com.capstone.bszip.Book.dto.SearchDto;
+import com.capstone.bszip.Book.service.SearchHistoriesSevice;
+import com.capstone.bszip.Member.domain.Member;
+import com.capstone.bszip.commonDto.ErrorResponse;
+import com.capstone.bszip.commonDto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "검색 기록", description = "검색 기록 관련 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SearchHistoriesController {
+
+    private final SearchHistoriesSevice searchHistoriesSevice;
+
+    @Operation(
+            summary = "검색어 저장",
+            description = "검색 성공 후 검색어와 검색 타입을 저장합니다. 책리뷰 검색기록은 searchtype을 'BOOKTITLE'로 해주세요."
+    )
+    @ApiResponse(responseCode = "200", description = "검색어 저장 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
+    @ApiResponse(responseCode = "500", description = "서버 에러 발생")
+    @PostMapping("/search-history")
+    public ResponseEntity<?> storeSearchHistories(@AuthenticationPrincipal Member member,
+                                                  @Valid @RequestBody SearchDto searchDto) {
+        try{
+            if(member == null){
+                return ResponseEntity.status(401).body(
+                        ErrorResponse.builder().status(401).result(false).message("로그인 후 이용해주세요.").build()
+                );
+            }
+
+            String searchWord = searchDto.getSearchWord();
+            String searchType = searchDto.getSearchType();
+
+            if(searchType == null || searchWord == null){
+                return ResponseEntity.status(400).body(
+                        ErrorResponse.builder().status(400).result(false).message("검색어와 검색타입을 모두 포함해주세요.").build()
+                );
+            }
+
+            searchHistoriesSevice.storeSearchHistories(searchType, searchWord, member);
+            return ResponseEntity.status(200).body(
+                    SuccessResponse.builder().status(200).result(true)
+                                    .message("성공적으로 검색어가 저장되었습니다🪱").build()
+            );
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(
+                    ErrorResponse.builder().result(false).status(500).message("검색어 저장 실패!").build()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class SearchHistories {
 
     @Id

--- a/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
@@ -1,0 +1,37 @@
+package com.capstone.bszip.Book.domain;
+
+import com.capstone.bszip.Member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "search_histories")
+@Builder(toBuilder = true)
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchHistories {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, name="search_word")
+    private String searchWord;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name="search_type")
+    private SearchType searchType;
+
+    @CreatedDate
+    @Column(nullable = false, name="search_date")
+    private LocalDateTime searchDate;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    Member member;
+}

--- a/src/main/java/com/capstone/bszip/Book/domain/SearchType.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/SearchType.java
@@ -1,0 +1,5 @@
+package com.capstone.bszip.Book.domain;
+
+public enum SearchType {
+    BOOKTITLE, AUTHOR;
+}

--- a/src/main/java/com/capstone/bszip/Book/dto/SearchDto.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/SearchDto.java
@@ -1,0 +1,12 @@
+package com.capstone.bszip.Book.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SearchDto {
+    @NotNull
+    String searchType;
+    @NotNull
+    String searchWord;
+}

--- a/src/main/java/com/capstone/bszip/Book/dto/SearchHistoryResponse.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/SearchHistoryResponse.java
@@ -5,11 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-public class SearchDto {
-    Long id;
-    String searchWord;
+public class SearchHistoryResponse {
+    List<?> searchHistory;
+    boolean isEnd;
+    int totalPages;
+    Long totalElements;
 }

--- a/src/main/java/com/capstone/bszip/Book/dto/SearchRequest.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/SearchRequest.java
@@ -1,0 +1,13 @@
+package com.capstone.bszip.Book.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SearchRequest {
+    @NotBlank
+    String searchType;
+    @NotNull
+    String searchWord;
+}

--- a/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
@@ -1,7 +1,13 @@
 package com.capstone.bszip.Book.repository;
 
 import com.capstone.bszip.Book.domain.SearchHistories;
+import com.capstone.bszip.Book.domain.SearchType;
+import com.capstone.bszip.Member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SearchHistoriesRepository extends CrudRepository<SearchHistories, Long> {
+    Page<SearchHistories> findByMemberAndSearchType(Member member, SearchType searchType, Pageable pageable);
 }

--- a/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.bszip.Book.repository;
+
+import com.capstone.bszip.Book.domain.SearchHistories;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SearchHistoriesRepository extends CrudRepository<SearchHistories, Long> {
+}

--- a/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
+++ b/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
@@ -2,13 +2,21 @@ package com.capstone.bszip.Book.service;
 
 import com.capstone.bszip.Book.domain.SearchHistories;
 import com.capstone.bszip.Book.domain.SearchType;
+import com.capstone.bszip.Book.dto.SearchDto;
+import com.capstone.bszip.Book.dto.SearchHistoryResponse;
 import com.capstone.bszip.Book.repository.SearchHistoriesRepository;
 import com.capstone.bszip.Member.domain.Member;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+// 📍성능 개선을 위해 추후에 Redis로 변경할 것
 @Service
 @Slf4j
 @AllArgsConstructor
@@ -25,6 +33,30 @@ public class SearchHistoriesSevice {
                 .searchType(type)
                 .build();
         searchHistoriesRepository.save(searchHistories);
+    }
+
+    public SearchHistoryResponse getSearchHistories(Member member, String searchType, int page, int size) {
+        SearchType type = SearchType.valueOf(searchType.toUpperCase());
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "searchDate"));
+        Page<?> s = searchHistoriesRepository.findByMemberAndSearchType(member, type, pageable);
+        Page<SearchDto> searchDtos =  searchHistoriesRepository.findByMemberAndSearchType(member, SearchType.BOOKTITLE, pageable)
+                .map(searchHistory -> {
+                            System.out.println(searchHistory.getSearchDate());
+                            System.out.println(searchHistory.getSearchType());
+                            System.out.println(searchHistory.getSearchWord());
+                    return SearchDto.builder()
+                            .id(searchHistory.getId())
+                            .searchWord(searchHistory.getSearchWord())
+                            .build();
+                        }
+                        );
+        System.out.println("💛" + searchDtos);
+        return SearchHistoryResponse.builder()
+                .searchHistory(searchDtos.getContent())
+                .isEnd(searchDtos.isLast())
+                .totalPages(searchDtos.getTotalPages())
+                .totalElements(searchDtos.getTotalElements())
+                .build();
     }
 
 

--- a/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
+++ b/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
@@ -1,0 +1,32 @@
+package com.capstone.bszip.Book.service;
+
+import com.capstone.bszip.Book.domain.SearchHistories;
+import com.capstone.bszip.Book.domain.SearchType;
+import com.capstone.bszip.Book.repository.SearchHistoriesRepository;
+import com.capstone.bszip.Member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class SearchHistoriesSevice {
+
+    private final SearchHistoriesRepository searchHistoriesRepository;
+
+
+    public void storeSearchHistories(String searchType, String searchWord, Member member) {
+        SearchType type = SearchType.valueOf(searchType.toUpperCase());
+        SearchHistories searchHistories = SearchHistories.builder()
+                .member(member)
+                .searchWord(searchWord)
+                .searchType(type)
+                .build();
+        searchHistoriesRepository.save(searchHistories);
+    }
+
+
+
+}

--- a/src/main/java/com/capstone/bszip/Member/domain/Member.java
+++ b/src/main/java/com/capstone/bszip/Member/domain/Member.java
@@ -2,6 +2,7 @@ package com.capstone.bszip.Member.domain;
 
 import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.PickedBook;
+import com.capstone.bszip.Book.domain.SearchHistories;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.ToString;
@@ -19,7 +20,7 @@ import java.util.Set;
 @Entity
 @Data
 @EntityListeners(AuditingEntityListener.class)
-@ToString(exclude = {"bookReviews", "bookReviewLikes", "pickedBooks"})
+@ToString(exclude = {"bookReviews", "bookReviewLikes", "pickedBooks", "searchHistoriesList"})
 @Table(name = "members") // 테이블 이름 매핑
 public class Member {
     @Id
@@ -65,4 +66,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PickedBook> pickedBooks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SearchHistories> searchHistoriesList = new ArrayList<>();
 }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용
* 현재는 메인디비에서만 검색어 관련 api가 작동하고 있는데, 추후에 성능최적화를 위해 redis로 변경하여 진행할 예정입니다.

### 📕POST : 책 검색 시 검색어 저장
* 북스냅에서 리뷰를 찾을 때, 책 제목을 검색하게 되는데 이 과정에서 최근 검색 기록을 보는 기능이 추가되어서 검색어 저장을 구현했습니다.
* 추후의 확장성을 위해서, 책 제목의 경우에는 searchtype을 booktitle로 받지만, 이후에 다른 곳에서 검색을 하게 되면 searchtype을 또 다르게 바꾸어서 받으려고 합니다...
*""이나 " "과 같은 경우에는 저장되지 않고 400 에러처리를 해두었습니다.

### 📖 GET : 최근 검색어 가지고 오기
* 현재는 최신순 정렬만 적용했는데, 내일 수업시간에 의견 받고 같은 검색어를 연달아 입력했을 때 처리도 생각해보려고 합니다!

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/2f2580ec-ae00-4519-b711-eab37409fab5)


<br/>

## 🔧 앞으로의 과제

- 책 검색 시 결과 없을 시 에러코드 처리 및 isEnd 오류 해결
- 리뷰 수정 메서드 patch로 변경
- 독립출판물 관련 db 수정 및 등록, 조회 api 구현

  <br/>

## ➕ 이슈 링크

- Backend #22 

<br/>
