### PR TITLE
fix(#22): 응답 쿼리 형식 변경 및 검색어 없는 경우 에러 처리

### DIFF
--- a/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
+++ b/src/main/java/com/capstone/bszip/Book/domain/SearchHistories.java
@@ -1,5 +1,6 @@
 package com.capstone.bszip.Book.domain;
 
+import com.capstone.bszip.Book.dto.SearchType;
 import com.capstone.bszip.Member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/capstone/bszip/Book/dto/BookSearchType.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/BookSearchType.java
@@ -1,0 +1,5 @@
+package com.capstone.bszip.Book.dto;
+
+public enum BookSearchType {
+    title, author;
+}

--- a/src/main/java/com/capstone/bszip/Book/dto/SearchType.java
+++ b/src/main/java/com/capstone/bszip/Book/dto/SearchType.java
@@ -1,4 +1,4 @@
-package com.capstone.bszip.Book.domain;
+package com.capstone.bszip.Book.dto;
 
 public enum SearchType {
     BOOKTITLE, AUTHOR;

--- a/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
+++ b/src/main/java/com/capstone/bszip/Book/repository/SearchHistoriesRepository.java
@@ -1,11 +1,10 @@
 package com.capstone.bszip.Book.repository;
 
 import com.capstone.bszip.Book.domain.SearchHistories;
-import com.capstone.bszip.Book.domain.SearchType;
+import com.capstone.bszip.Book.dto.SearchType;
 import com.capstone.bszip.Member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SearchHistoriesRepository extends CrudRepository<SearchHistories, Long> {

--- a/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
+++ b/src/main/java/com/capstone/bszip/Book/service/SearchHistoriesSevice.java
@@ -1,7 +1,7 @@
 package com.capstone.bszip.Book.service;
 
 import com.capstone.bszip.Book.domain.SearchHistories;
-import com.capstone.bszip.Book.domain.SearchType;
+import com.capstone.bszip.Book.dto.SearchType;
 import com.capstone.bszip.Book.dto.SearchDto;
 import com.capstone.bszip.Book.dto.SearchHistoryResponse;
 import com.capstone.bszip.Book.repository.SearchHistoriesRepository;
@@ -14,8 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
 // 📍성능 개선을 위해 추후에 Redis로 변경할 것
 @Service
 @Slf4j


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

### 📖 응답 형식 변경
* 위와 같이, booktitle과 author를 type으로 쿼리로 받아 구분할 수 있도록 했습니다.

### 📖책 검색 시에 빈 검색어 입력 시 에러 처리
* 이전에는 빈 배열을 보낼 수 `isEnd`가 `false`고 빈배열을 그대로 보내주었습니다.
* 이제는 아래와 같이 보내주겠습니다. 세심하지 못하네요 😅😅
  ```
  {
  "result": false,
  "status": 400,
  "message": "E01: 검색어를 입력해주세요.",
  "detail": "E01"
  }
 
<br/>

## 이미지
![image](https://github.com/user-attachments/assets/c5906be5-ed86-4a99-9df2-a63b55c77e1b)


<br/>

## 🔧 앞으로의 과제

- 리뷰 put-> patch로 바꾸기
- 독립출판물 관련 api 만들기

  <br/>

## ➕ 이슈 링크

- Backend #22 

<br/>
