### PR TITLE
 feat(#60): 서점 리뷰 생성 및 서점 상세 정보 조회 

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -3,6 +3,7 @@ package com.capstone.bszip.Bookstore.controller;
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.service.BookstoreService;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreDetailResponse;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
 import com.capstone.bszip.Member.domain.Member;
 import com.capstone.bszip.commonDto.ErrorResponse;
@@ -227,5 +228,21 @@ public class BookstoreController {
                             .detail(e.getMessage())
                             .build());
         }
+    }
+
+    @GetMapping("/{bookstoreId}")
+    public ResponseEntity<?> getBookstoreDetail(@PathVariable Long bookstoreId,
+                                          @AuthenticationPrincipal Member member){
+
+            BookstoreDetailResponse bookstoreDetail = bookstoreService.getBookstoreDetail(member,bookstoreId);
+
+            return ResponseEntity.ok(SuccessResponse.<BookstoreDetailResponse> builder()
+                    .result(true)
+                    .status(HttpStatus.OK.value())
+                    .message("서점 상세 정보")
+                    .data(bookstoreDetail)
+                    .build());
+
+
     }
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -52,7 +52,7 @@ public class BookstoreController {
                                               @RequestParam double lat, @RequestParam double lng) {
         try {
             List<BookstoreResponse> bookstores = bookstoreService.searchBookstores(keyword,member,lat,lng);
-            if (bookstores.isEmpty()) {
+            /*if (bookstores.isEmpty()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(ErrorResponse.builder()
                                 .result(false)
@@ -60,7 +60,7 @@ public class BookstoreController {
                                 .message("검색 결과가 없습니다.")
                                 .detail(keyword+" 에 해당하는 서점이 없습니다.")
                                 .build());
-            }
+            }*/
             return ResponseEntity.ok(SuccessResponse.<List<BookstoreResponse>>builder()
                     .result(true)
                     .status(HttpStatus.OK.value())

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -136,7 +136,7 @@ public class BookstoreController {
 
     @Operation(
             summary = "서점 찜하기/찜 취소",
-            description = "특정 서점에 대해 찜하기 또는 찜 취소를 수행합니다."
+            description = "[로그인 필수] 특정 서점에 대해 찜하기 또는 찜 취소를 수행합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 찜하기/찜 취소 수행"),
@@ -185,7 +185,7 @@ public class BookstoreController {
 
     @Operation(
             summary = "찜한 서점 목록 조회",
-            description = "현재 로그인한 사용자가 찜한 서점 목록을 반환합니다."
+            description = "[로그인 필수] 사용자가 찜한 서점 목록을 반환합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 찜한 서점 목록 반환"),
@@ -233,7 +233,16 @@ public class BookstoreController {
                             .build());
         }
     }
-
+    @Operation(
+            summary = "서점 상세 조회",
+            description = "특정 서점의 상세 정보 및 리뷰 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "서점 상세 정보 및 리뷰 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BookstoreDetailWithReviews.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/{bookstoreId}")
     public ResponseEntity<?> getBookstoreDetail(@PathVariable Long bookstoreId,
                                                 @AuthenticationPrincipal Member member){
@@ -244,9 +253,26 @@ public class BookstoreController {
             return ResponseEntity.ok(SuccessResponse.<BookstoreDetailWithReviews>builder()
                     .result(true)
                     .status(HttpStatus.OK.value())
-                    .message("서점 상세 정보")
-                    .data(bookstoreDetail)
+                    .message("서점 상세 정보 및 리뷰 조회 성공")
+                    .data(new BookstoreDetailWithReviews(bookstoreDetail,reviewList))
                     .build());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ErrorResponse.builder()
+                            .result(false)
+                            .status(HttpStatus.NOT_FOUND.value())
+                            .message("서점 id 오류")
+                            .detail(e.getMessage())
+                            .build());
+        }catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ErrorResponse.builder()
+                            .result(false)
+                            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                            .message("서버 오류가 발생했습니다.")
+                            .detail(e.getMessage())
+                            .build());
+        }
 
 
     }

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -2,9 +2,12 @@ package com.capstone.bszip.Bookstore.controller;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
+import com.capstone.bszip.Bookstore.service.BookstoreReviewService;
 import com.capstone.bszip.Bookstore.service.BookstoreService;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreDetailResponse;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreDetailWithReviews;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreReviewResponse;
 import com.capstone.bszip.Member.domain.Member;
 import com.capstone.bszip.commonDto.ErrorResponse;
 import com.capstone.bszip.commonDto.SuccessResponse;
@@ -35,6 +38,7 @@ import java.util.Map;
 public class BookstoreController {
 
     private final BookstoreService bookstoreService;
+    private final BookstoreReviewService bookstoreReviewService;
 
     @Operation(summary = "서점 검색", description = "검색창에서 서점을 이름,주소로 검색합니다.")
     @ApiResponses(value = {
@@ -232,11 +236,12 @@ public class BookstoreController {
 
     @GetMapping("/{bookstoreId}")
     public ResponseEntity<?> getBookstoreDetail(@PathVariable Long bookstoreId,
-                                          @AuthenticationPrincipal Member member){
+                                                @AuthenticationPrincipal Member member){
+        try {
+            BookstoreDetailResponse bookstoreDetail = bookstoreService.getBookstoreDetail(member, bookstoreId);
+            List<BookstoreReviewResponse> reviewList = bookstoreReviewService.getReviewsByBookstoreId(bookstoreId);
 
-            BookstoreDetailResponse bookstoreDetail = bookstoreService.getBookstoreDetail(member,bookstoreId);
-
-            return ResponseEntity.ok(SuccessResponse.<BookstoreDetailResponse> builder()
+            return ResponseEntity.ok(SuccessResponse.<BookstoreDetailWithReviews>builder()
                     .result(true)
                     .status(HttpStatus.OK.value())
                     .message("서점 상세 정보")

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreReviewController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreReviewController.java
@@ -1,0 +1,86 @@
+package com.capstone.bszip.Bookstore.controller;
+
+import com.capstone.bszip.Bookstore.service.BookstoreReviewService;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreReviewRequest;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreReviewResponse;
+import com.capstone.bszip.Member.domain.Member;
+import com.capstone.bszip.commonDto.ErrorResponse;
+import com.capstone.bszip.commonDto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/bookstore/reviews")
+@RequiredArgsConstructor
+@Tag(name = "BookstoreReview", description = "서점 리뷰 관리 API")
+public class BookstoreReviewController {
+
+    private final BookstoreReviewService bookstoreReviewService;
+    @Operation(
+            summary = "서점 리뷰 등록",
+            description = "[로그인 필수] 사용자가 특정 서점에 리뷰를 작성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "리뷰 등록 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "서점 ID 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<?> createReview(
+            @AuthenticationPrincipal Member member,
+            @RequestBody BookstoreReviewRequest request
+            ) {
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ErrorResponse.builder()
+                            .result(false)
+                            .status(HttpStatus.UNAUTHORIZED.value())
+                            .message("인증되지 않은 사용자입니다.")
+                            .detail("로그인이 필요한 서비스입니다.")
+                            .build());
+        }
+        try {
+            BookstoreReviewResponse response = bookstoreReviewService.createReview(member, request);
+            return ResponseEntity.ok(SuccessResponse.<BookstoreReviewResponse>builder()
+                    .result(true)
+                    .status(HttpStatus.CREATED.value())
+                    .message("서점 리뷰 등록 성공")
+                    .data(response)
+                    .build());
+        }catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ErrorResponse.builder()
+                            .result(false)
+                            .status(HttpStatus.NOT_FOUND.value())
+                            .message("서점 id 오류")
+                            .detail(e.getMessage())
+                            .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ErrorResponse.builder()
+                            .result(false)
+                            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                            .message("서버 오류가 발생했습니다.")
+                            .detail(e.getMessage())
+                            .build());
+        }
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Data
 @Builder(toBuilder = true) // toBuilder = true 옵션 추가
@@ -53,4 +55,7 @@ public class Bookstore {
     public Bookstore updateRating(double newRating) {
         return this.toBuilder().rating(newRating).build();
     }
+
+    @OneToMany(mappedBy = "bookstore", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookstoreReview> bookstoreReviews;
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/BookstoreReview.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/BookstoreReview.java
@@ -1,0 +1,45 @@
+package com.capstone.bszip.Bookstore.domain;
+
+import com.capstone.bszip.Book.domain.Book;
+import com.capstone.bszip.Member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Table(name="bookstore_reviews")
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookstoreReview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="bookstorereview_id")
+    private Long bookstoreReviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bookstore_id",referencedColumnName = "bookstore_id", nullable = false)
+    private Bookstore bookstore;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id",nullable = false)
+    private Member member;
+
+    @Column(name="rating")
+    private double rating;
+
+    @Column(name="text")
+    private String text;
+
+    @Column(name="image_url")
+    private String imageUrl;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreReviewRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreReviewRepository.java
@@ -1,0 +1,15 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.BookstoreReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BookstoreReviewRepository extends JpaRepository<BookstoreReview, Long> {
+    @Query("SELECT r FROM BookstoreReview r " +
+            "WHERE r.bookstore.bookstoreId = :bookstoreId " +
+            "ORDER BY r.createdAt DESC")
+    List<BookstoreReview> findReviewsByBookstoreIdOrderByCreatedAtDesc(@Param("bookstoreId") Long bookstoreId);
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreReviewService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreReviewService.java
@@ -1,0 +1,47 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.domain.BookstoreReview;
+import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import com.capstone.bszip.Bookstore.repository.BookstoreReviewRepository;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreReviewRequest;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreReviewResponse;
+import com.capstone.bszip.Member.domain.Member;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookstoreReviewService {
+    private final BookstoreRepository bookstoreRepository;
+    private final BookstoreReviewRepository bookstoreReviewRepository;
+
+    @Transactional
+    public BookstoreReviewResponse createReview(Member member, BookstoreReviewRequest request){
+        Bookstore bookstore = bookstoreRepository.findById(request.getBookstoreId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 서점을 찾을 수 없습니다."));
+
+        BookstoreReview review = new BookstoreReview();
+        review.setBookstore(bookstore);
+        review.setMember(member);
+        review.setRating(request.getRating());
+        review.setText(request.getText());
+        review.setImageUrl(request.getImageUrl());
+
+        bookstoreReviewRepository.save(review);
+
+        return new BookstoreReviewResponse(
+                review.getBookstoreReviewId(),
+                member.getNickname(),
+                review.getRating(),
+                review.getText(),
+                review.getImageUrl(),
+                review.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreReviewService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreReviewService.java
@@ -44,4 +44,21 @@ public class BookstoreReviewService {
                 review.getCreatedAt()
         );
     }
+    public List<BookstoreReviewResponse> getReviewsByBookstoreId(Long bookstoreId){
+        List<BookstoreReview> reviews = bookstoreReviewRepository.findReviewsByBookstoreIdOrderByCreatedAtDesc(bookstoreId);
+        return reviews.stream()
+                .map(this::convertToBookstoreResponse)
+                .collect(Collectors.toList());
+    }
+    private BookstoreReviewResponse convertToBookstoreResponse(BookstoreReview review) {
+
+        return new BookstoreReviewResponse(
+                review.getBookstoreReviewId(),
+                review.getMember().getNickname(),
+                review.getRating(),
+                review.getText(),
+                review.getImageUrl(),
+                review.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -3,6 +3,7 @@ package com.capstone.bszip.Bookstore.service;
 import com.capstone.bszip.Bookstore.domain.Bookstore;
 import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import com.capstone.bszip.Bookstore.service.dto.BookstoreDetailResponse;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
 import com.capstone.bszip.Member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -109,4 +112,37 @@ public class BookstoreService {
                     .collect(Collectors.toList());
         }
     }
+
+    public BookstoreDetailResponse getBookstoreDetail(Member member, Long bookstoreId){
+        Optional<Bookstore> bs = bookstoreRepository.findById(bookstoreId);
+
+        if (bs.isEmpty()) {
+            return null;
+        }
+        Bookstore bookstore = bs.get(); // 값이 있는 경우만 접근
+
+
+        boolean isLiked;
+        if(member != null){
+            isLiked = checkIfBookstoreLiked(member.getMemberId(),bookstore.getBookstoreId());
+        }else{ //로그인 안한 사용자
+            isLiked = false;
+        }
+        String modKeyword=bookstore.getKeyword();
+        if(modKeyword.equals(" 일반")){
+            modKeyword =" 일반서적";
+        }
+        return new BookstoreDetailResponse(
+                bookstore.getBookstoreId(),
+                bookstore.getName(),
+                bookstore.getPhone(),
+                bookstore.getHours(),
+                bookstore.getRating(),
+                modKeyword,
+                bookstore.getAddress().substring(8),
+                bookstore.getDescription(),
+                isLiked
+        );
+    }
+
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/BookstoreService.java
@@ -6,6 +6,7 @@ import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreDetailResponse;
 import com.capstone.bszip.Bookstore.service.dto.BookstoreResponse;
 import com.capstone.bszip.Member.domain.Member;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -114,13 +115,8 @@ public class BookstoreService {
     }
 
     public BookstoreDetailResponse getBookstoreDetail(Member member, Long bookstoreId){
-        Optional<Bookstore> bs = bookstoreRepository.findById(bookstoreId);
-
-        if (bs.isEmpty()) {
-            return null;
-        }
-        Bookstore bookstore = bs.get(); // 값이 있는 경우만 접근
-
+        Bookstore bookstore = bookstoreRepository.findById(bookstoreId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 서점을 찾을 수 없습니다."));
 
         boolean isLiked;
         if(member != null){

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreDetailResponse.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreDetailResponse.java
@@ -1,0 +1,20 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class BookstoreDetailResponse {
+    private Long bookstoreId;
+    private String name;
+    private String phone;
+    private String hours;
+    private double rating;
+    private String keyword;
+    private String address;
+    private String description;
+    private boolean liked;
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreDetailWithReviews.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreDetailWithReviews.java
@@ -1,0 +1,15 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class BookstoreDetailWithReviews {
+    private BookstoreDetailResponse bookstoreDetail;
+    private List<BookstoreReviewResponse> reviewList;
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreReviewRequest.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreReviewRequest.java
@@ -1,0 +1,18 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookstoreReviewRequest {
+    private Long bookstoreId;
+    @Min(1) @Max(5)
+    private int rating;
+    private String text;
+    private String imageUrl;
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreReviewResponse.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/BookstoreReviewResponse.java
@@ -1,0 +1,17 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class BookstoreReviewResponse {
+    private Long bookstoreReviewId;
+    private String nickname;
+    private double rating;
+    private String text;
+    private String imageUrl;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/capstone/bszip/Member/domain/Member.java
+++ b/src/main/java/com/capstone/bszip/Member/domain/Member.java
@@ -2,6 +2,7 @@ package com.capstone.bszip.Member.domain;
 
 import com.capstone.bszip.Book.domain.BookReview;
 import com.capstone.bszip.Book.domain.PickedBook;
+import com.capstone.bszip.Bookstore.domain.BookstoreReview;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.ToString;
@@ -19,7 +20,7 @@ import java.util.Set;
 @Entity
 @Data
 @EntityListeners(AuditingEntityListener.class)
-@ToString(exclude = {"bookReviews", "bookReviewLikes", "pickedBooks"})
+@ToString(exclude = {"bookReviews", "bookReviewLikes", "pickedBooks","bookstoreReviews"})
 @Table(name = "members") // 테이블 이름 매핑
 public class Member {
     @Id
@@ -65,4 +66,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PickedBook> pickedBooks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookstoreReview> bookstoreReviews = new ArrayList<>();
 }

--- a/src/main/java/com/capstone/bszip/auth/security/JwtExceptionFilter.java
+++ b/src/main/java/com/capstone/bszip/auth/security/JwtExceptionFilter.java
@@ -22,11 +22,13 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try{
             filterChain.doFilter(request,response);
         }catch (ExpiredJwtException e){
-            AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,e.getMessage());
+            AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,"JWT 토큰 만료: " + e.getMessage());
         } catch (JwtException e) {
-            AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,e.getMessage());
+            AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,"JWT 오류: " + e.getMessage());
         } catch (Exception e) {
-            AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,e.getMessage());
+            //AuthErrorResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED,e.getMessage());
+            // JWT 관련 없는 예외는 필터 체인으로 넘김
+            throw e;
         }
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 서점 리뷰 (Bookstore, Member와 연관됨)
- 서점 리뷰 생성 
- 서점 상세 조회 *최신순 리뷰

- 및 에러 처리와 jwt 토큰 오류로 처리되던 filter 부분도 수정했습니다 
- 이제 jwt 토큰 에러라고 안뜰것임 ..


  <br/>

## 이미지 첨부
서점 리뷰 생성하는 api 입니닷
![image](https://github.com/user-attachments/assets/6de75ee0-4868-425d-b993-7c4f4ee21ccb)
*bookstoreId 포함해서 넘겨서 생성함

[error 처리]
- 401 : 로그인 필수 
- 404 : 해당 서점 id를 찾을 수 없을때
- 500 : 그외 서버에러



![image](https://github.com/user-attachments/assets/766379f3-3752-46ba-bb61-228db31be39a)
- bookstoreId로 조회해서 
- 상세정보와 리뷰 리스트를 반환합니다 

- 일단 최신순으로 구현
- 리뷰 없을때 빈 배열 반환합니다
- *서점 결과도 없을 때 빈 배열 반환으로 수정했습니다 ~!

<br/>

## 🔧 앞으로의 과제

-  별점 계산해야되고 
- 서점 상세 조회 별점순 
- 서점 보유 책 ..
- 찜 개수도 계산해야됨
  <br/>

## ➕ 이슈 링크

- [Backend #60](https://github.com/TEAM-ZIP/Backend/issues/60)

<br/>
