### PR TITLE
feat(TEAM-ZIP#23): 급상승 서점 조회 api

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/BookstoreLikeTrendingScheduler.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/BookstoreLikeTrendingScheduler.java
@@ -1,0 +1,21 @@
+package com.capstone.bszip.Bookstore;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookstoreLikeTrendingScheduler {
+
+    private final RedisTemplate<String,String> redisTemplate;
+
+    @Scheduled(cron="0 0 0 * * MON")
+    public void resetWeeklyTrend(){
+        // 백업
+        redisTemplate.rename("trending:bookstores:weekly", "trending:bookstores:lastweek");
+        // 초기화
+        redisTemplate.delete("trending:bookstores:weekly");
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -310,6 +310,21 @@ public class BookstoreController {
         }
     }
 
+    @Operation(
+            summary = "급상승 독립서점 목록 조회",
+            description = "관심 급상승(weekly 인기순) 독립서점 이름 리스트를 반환합니다. " +
+                    "데이터 10개를 제공하며 부족할 경우 지난 주 랭킹/전체 서점에서 순차적으로 채워집니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "급상승 서점 목록 조회 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "급상승 서점 정보가 존재하지 않음",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "503", description = "Redis 연결 실패 등 서비스 일시적 장애",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/trending")
     public ResponseEntity<?> getTrendingBookstores(){
         try {

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
@@ -40,4 +40,7 @@ public interface BookstoreRepository extends JpaRepository<Bookstore,Long> {
     List<Bookstore> findAllByNameContaining(String name);
 
     List<Bookstore> findTop10ByOrderByBookstoreIdDesc();
+
+    @Query("SELECT b.bookstoreId, b.name FROM Bookstore b WHERE b.bookstoreId IN :ids")
+    List<Object[]> findIdAndNameByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/capstone/bszip/Member/controller/MemberController.java
+++ b/src/main/java/com/capstone/bszip/Member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.capstone.bszip.Member.controller;
 
+import com.capstone.bszip.Member.service.dto.LoginResponse;
 import com.capstone.bszip.auth.dto.TokenRequest;
 import com.capstone.bszip.auth.dto.TokenResponse;
 import com.capstone.bszip.auth.AuthService;
@@ -127,13 +128,13 @@ public class MemberController {
 
     public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response){
         try{
-             TokenResponse tokens = memberService.loginUser(loginRequest);
-             authService.login(loginRequest.getEmail(), tokens.getRefreshToken());
+             LoginResponse loginResponse = memberService.loginUser(loginRequest);
+             authService.login(loginRequest.getEmail(), loginResponse.getRefreshToken());
             return ResponseEntity.ok(SuccessResponse.builder()
                     .result(true)
                     .status(HttpStatus.OK.value())
                     .message("로그인 성공")
-                    .data(tokens)
+                    .data(loginResponse)
                     .build());
         } catch (BadCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/src/main/java/com/capstone/bszip/Member/service/MemberService.java
+++ b/src/main/java/com/capstone/bszip/Member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.capstone.bszip.Member.service;
 import com.capstone.bszip.Member.domain.Member;
 import com.capstone.bszip.Member.domain.MemberJoinType;
 import com.capstone.bszip.Member.repository.MemberRepository;
+import com.capstone.bszip.Member.service.dto.LoginResponse;
 import com.capstone.bszip.auth.dto.TokenResponse;
 import com.capstone.bszip.auth.security.JwtUtil;
 import com.capstone.bszip.Member.service.dto.LoginRequest;
@@ -82,7 +83,7 @@ public class MemberService {
         temporaryStorage.remove(email);
     }
     @Transactional
-    public TokenResponse loginUser(LoginRequest loginRequest){
+    public LoginResponse loginUser(LoginRequest loginRequest){
         Member member = memberRepository.findByEmail(loginRequest.getEmail())
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 이메일입니다."));
         if(member.getMemberJoinType() != DEFAULT){
@@ -90,10 +91,11 @@ public class MemberService {
         }
         if(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
             String email = member.getEmail();
+            String nickname = member.getNickname();
             //토큰 생성
             String accessToken = JwtUtil.createAccessToken(email);
             String refreshToken = JwtUtil.createRefreshToken(email);
-            return new TokenResponse(accessToken, refreshToken);
+            return new LoginResponse(nickname,accessToken, refreshToken);
         }
         else {
             throw new RuntimeException("일치하지 않는 비밀번호입니다.");

--- a/src/main/java/com/capstone/bszip/Member/service/dto/LoginResponse.java
+++ b/src/main/java/com/capstone/bszip/Member/service/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.capstone.bszip.Member.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponse {
+    private String nickname;
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 서점 검색 페이지의 급상승 서점 api (/api/bookstore/trending)

  <br/>

## 이미지 첨부
![스크린샷 2025-05-08 145627](https://github.com/user-attachments/assets/a708f2fe-5759-44ae-afe2-aabd37a3681b)
- 좋아요한 서점 없을 때 : 기본 서점 1-10 리스트 조회
![스크린샷 2025-05-08 151022](https://github.com/user-attachments/assets/634106ec-369b-4cbf-aacd-5b27b871d9d5)

<br/>

## 🔧 앞으로의 과제

- 지금은 그냥 List<String> 으로 반환하는데 id값도 넘겨서 서점 상세 페이지로 이동하게도 수정 가능 .. 
  <br/>

## ➕ 이슈 링크

- [Backend #23 ](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
