### PR TITLE
feat(TEAM-ZIP#23): 서점 검색 쿼리 수정

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/controller/BookstoreController.java
@@ -56,11 +56,13 @@ public class BookstoreController {
                     content = @Content(schema = @Schema(implementation = String.class)))
     })
     @GetMapping("/search")
-    public ResponseEntity<?> searchBookstores(@RequestParam String keyword,
+    public ResponseEntity<?> searchBookstores(@RequestParam(required = false) String searchK,
+                                              @RequestParam(required = false) List<String> bookstoreK,
+                                              @RequestParam(required = false) String region,
                                               @AuthenticationPrincipal Member member,
                                               @RequestParam double lat, @RequestParam double lng) {
         try {
-            List<BookstoreResponse> bookstores = bookstoreService.searchBookstores(keyword, member, lat, lng);
+            List<BookstoreResponse> bookstores = bookstoreService.searchBookstores(searchK,bookstoreK,region, member, lat, lng);
             /*if (bookstores.isEmpty()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(ErrorResponse.builder()
@@ -73,7 +75,7 @@ public class BookstoreController {
             return ResponseEntity.ok(SuccessResponse.<List<BookstoreResponse>>builder()
                     .result(true)
                     .status(HttpStatus.OK.value())
-                    .message(keyword + " - 서점 검색 성공")
+                    .message(searchK + bookstoreK + region + " - 서점 검색 성공")
                     .data(bookstores)
                     .build());
         } catch (IllegalArgumentException e) {
@@ -94,7 +96,7 @@ public class BookstoreController {
                             .build());
         }
     }
-
+    /*
     @Operation(
             summary = "카테고리별 서점 조회",
             description = "지정된 카테고리에 해당하는 서점 목록을 반환합니다. 카테고리가 지정되지 않으면 모든 서점을 반환합니다."
@@ -136,7 +138,7 @@ public class BookstoreController {
                             .detail(e.getMessage())
                             .build());
         }
-    }
+    }*/
 
     @Operation(
             summary = "서점 찜하기/찜 취소",

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepository.java
@@ -1,35 +1,14 @@
 package com.capstone.bszip.Bookstore.repository;
 
 import com.capstone.bszip.Bookstore.domain.Bookstore;
-import com.capstone.bszip.Bookstore.domain.BookstoreCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface BookstoreRepository extends JpaRepository<Bookstore,Long> {
-    @Query(value = "SELECT *, (6371 * acos(cos(radians(:userLat)) * cos(radians(latitude)) " +
-            "* cos(radians(longitude) - radians(:userLng)) + sin(radians(:userLat)) * sin(radians(latitude)))) " +
-            "AS distance FROM bookstores WHERE (:name IS NULL OR name LIKE %:name%)" +
-            "OR (:address IS NULL OR address LIKE %:address%) ORDER BY distance ASC", nativeQuery = true)
-    List<Bookstore> findByNameOrAddressOrderByDistance(String name, String address,
-                                                       @Param("userLat") double userLat,
-                                                       @Param("userLng") double userLng);
-
-    @Query(value = "SELECT *, (6371 * acos(cos(radians(:userLat)) * cos(radians(latitude)) " +
-            "* cos(radians(longitude) - radians(:userLng)) + sin(radians(:userLat)) * sin(radians(latitude)))) " +
-            "AS distance FROM bookstores ORDER BY distance ASC", nativeQuery = true)
-    List<Bookstore> findAllOrderByDistance(@Param("userLat") double userLat,
-                                           @Param("userLng") double userLng);
-
-    @Query(value = "SELECT *, (6371 * acos(cos(radians(:userLat)) * cos(radians(latitude)) " +
-            "* cos(radians(longitude) - radians(:userLng)) + sin(radians(:userLat)) * sin(radians(latitude)))) " +
-            "AS distance FROM bookstores WHERE category LIKE %:category% ORDER BY distance ASC  ", nativeQuery = true)
-    List<Bookstore> findByBookstoreCategoryByDistance(@Param("category") BookstoreCategory category,
-                                                      @Param("userLat") double userLat,
-                                                      @Param("userLng") double userLng);
-
+public interface BookstoreRepository extends JpaRepository<Bookstore,Long>, JpaSpecificationExecutor<Bookstore>,BookstoreRepositoryCustom{
     @Query(value = "SELECT *, (6371 * acos(cos(radians(:userLat)) * cos(radians(latitude)) " +
             "* cos(radians(longitude) - radians(:userLng)) + sin(radians(:userLat)) * sin(radians(latitude)))) " +
             "AS distance FROM bookstores WHERE bookstore_id IN :bookstoreIds ORDER BY distance ASC", nativeQuery = true)

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepositoryCustom.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+public interface BookstoreRepositoryCustom {
+    List<Bookstore> findWithFiltersOrderByDistance(Specification<Bookstore> spec,
+                                                   double userLat,
+                                                   double userLng);
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepositoryImpl.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class BookstoreRepositoryImpl implements BookstoreRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public List<Bookstore> findWithFiltersOrderByDistance(Specification<Bookstore> spec,
+                                                          double userLat,
+                                                          double userLng){
+        // spec 조건으로 1차 필터링 
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> query = builder.createQuery(Long.class);
+        Root<Bookstore> root = query.from(Bookstore.class);
+
+        if(spec != null) {
+            query.where(spec.toPredicate(root,query,builder));
+        }
+
+        query.select(root.get("bookstoreId"));
+        List<Long> filteredIds = em.createQuery(query).getResultList();
+
+        // native query로 2차 거리순 필터링
+        if(filteredIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String nativeQuery = "SELECT b.*, " +
+                "(6371 * acos(cos(radians(:userLat)) * cos(radians(b.latitude)) " +
+                "* cos(radians(b.longitude) - radians(:userLng)) + sin(radians(:userLat)) * sin(radians(b.latitude)))) " +
+                "AS distance " +
+                "FROM bookstores b " +
+                "WHERE b.bookstore_id IN (:filteredIds) " +
+                "ORDER BY distance ASC";
+
+        org.hibernate.query.NativeQuery<?> hibernateQuery =
+                em.createNativeQuery(nativeQuery, Bookstore.class)
+                        .unwrap(org.hibernate.query.NativeQuery.class);
+
+        hibernateQuery.setParameter("userLat", userLat);
+        hibernateQuery.setParameter("userLng", userLng);
+        hibernateQuery.setParameterList("filteredIds", filteredIds);
+
+        return (List<Bookstore>) hibernateQuery.getResultList();
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreSpecs.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/BookstoreSpecs.java
@@ -1,0 +1,57 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BookstoreSpecs {
+    // 검색 키워드 - name/address 칼럼에서 키워드를 포함하는 서점 반환
+    public static Specification<Bookstore> nameOrAddressContains(String searchK) {
+        return (root, query, cb) -> {
+            if (searchK == null || searchK.isEmpty()) return null;
+            String pattern = "%" + searchK + "%";
+            return cb.or(
+                    cb.like(root.get("name"), pattern),
+                    cb.like(root.get("address"), pattern)
+            );
+        };
+    }
+    // 필터 키워드 리스트 - keyword 칼럼에서 키워드를 포함하는 서점 반환
+    public static Specification<Bookstore> keywordIn(List<String> bookstoreK) {
+        return (root, query, cb) -> {
+            if (bookstoreK == null || bookstoreK.isEmpty()) return null;
+
+            // 리스트의 각 키워드에 대해 LIKE 조건 생성
+            List<Predicate> predicates = new ArrayList<>();
+            for (String k : bookstoreK) {
+                // 키워드에서 공백 제거
+                String processedK = k.replace(" ", "");
+
+                /*DB의 keyword 컬럼에서 공백 제거 및 소문자 변환
+                Expression<String> dbKeywordNoSpace = cb.function(
+                        "REPLACE", String.class,
+                        cb.lower(root.get("keyword")),
+                        cb.literal(" "), cb.literal("")
+                );*/
+                // LIKE 조건 생성
+                predicates.add(cb.like(root.get("keyword"), "%" + processedK + "%"));
+            }
+
+            // 모든 LIKE 조건을 OR로 결합 (여러 키워드 중 하나라도 일치하면 반환)
+            return cb.or(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    // 필터 지역 - address 칼럼에서 지역 해당하는 서점 반환
+    public static Specification<Bookstore> regionContains(String region) {
+        return (root, query, cb) -> {
+            if (region == null || region.isEmpty()) return null;
+            String pattern = "%" + region + "%";
+            return cb.like(root.get("address"), pattern);
+        };
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 서점 검색 쿼리 수정했습니다.
![image](https://github.com/user-attachments/assets/1544f421-ef91-437b-a0a5-63880e2e9cc1)

Specification
- 검색어 -> searchK
- 필터에서 지역 -> region
- 필터에서 북스테이,북카페,서적종류 -> bookstoreK (String 리스트) 
*북스테이, 서적 종류 등이 db에 다 keyword 칼럼으로 있어서 리스트로 받아서 한번에 검색함 

BookstoreRepositoryImpl
- 기존 거리순 정렬 native 쿼리로 필터링되도록 

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/64e49dbd-64f9-4694-b577-4cee2ae30a9e)
![image](https://github.com/user-attachments/assets/d2b34d1e-3060-4263-9c4f-0287f52d2e83)

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [Backend #23](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
