### PR TITLE
feat(TEAM-ZIP#23): 서점 해시태그 추출 및 조회 api

### DIFF
--- a/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/Bookstore.java
@@ -65,4 +65,13 @@ public class Bookstore {
 
     @OneToMany(mappedBy = "bookstore", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookstoreReview> bookstoreReviews;
+
+    @OneToOne(mappedBy = "bookstore", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Hashtag hashtag;
+
+    @Builder
+    public Bookstore(Long bookstoreId, Hashtag hashtag) {
+        this.bookstoreId = bookstoreId;
+        this.hashtag = hashtag;
+    }
 }

--- a/src/main/java/com/capstone/bszip/Bookstore/domain/Hashtag.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/domain/Hashtag.java
@@ -1,0 +1,24 @@
+package com.capstone.bszip.Bookstore.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hashtag {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "bookstore_id", unique = true) // 외래 키 + 유니크 제약
+    private Bookstore bookstore;
+
+    @Column(unique = true, nullable = false)
+    private String tag;
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/repository/HashtagRepository.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/repository/HashtagRepository.java
@@ -1,0 +1,18 @@
+package com.capstone.bszip.Bookstore.repository;
+
+import com.capstone.bszip.Bookstore.domain.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<Hashtag,Long> {
+    boolean existsByTag(String tag);
+
+    Optional<Hashtag> findByTag(String tag);
+
+    @Query(value = "SELECT * FROM hashtag ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Hashtag> findRandomHashtags(@Param("limit") int limit);
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/HashtagExtractorService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/HashtagExtractorService.java
@@ -1,0 +1,67 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class HashtagExtractorService {
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final RestTemplate restTemplate = new RestTemplate();
+    @Value("${openai.api.key}")
+    private String API_KEY;
+
+    public String extractHashtag(String description) {
+        System.out.println(description);
+        String prompt = String.format(
+                "아래 서점 설명을 참고해서, 이전에 추출한 해시태그와 중복되지 않는, 새로운 해시태그 한 개만 추출해줘. " +
+                        "북스테이,북카페,서적 은 따로 저장하고 있으니 제외해줘  " +
+                        "설명: \"%s\" 결과는 해시태그 한 개만 반환해줘. 예시: #고양이", description);
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            Map<String, Object> requestMap = new HashMap<>();
+            requestMap.put("model", "gpt-4");
+
+            List<Map<String, String>> messages = new ArrayList<>();
+            Map<String, String> message = new HashMap<>();
+            message.put("role", "user");
+            message.put("content", prompt); // 이스케이프 자동 처리
+
+            messages.add(message);
+            requestMap.put("messages", messages);
+
+            String requestBody = mapper.writeValueAsString(requestMap);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(API_KEY);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(OPENAI_API_URL, HttpMethod.POST, entity, String.class);
+            String content = response.getBody();
+            System.out.println(content);
+            Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+            Matcher matcher = pattern.matcher(content);
+            if (matcher.find()) {
+                return matcher.group();
+            }
+            return null;
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/com/capstone/bszip/Bookstore/service/HashtagService.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/HashtagService.java
@@ -1,0 +1,60 @@
+package com.capstone.bszip.Bookstore.service;
+
+import com.capstone.bszip.Bookstore.domain.Bookstore;
+import com.capstone.bszip.Bookstore.domain.Hashtag;
+import com.capstone.bszip.Bookstore.repository.BookstoreRepository;
+import com.capstone.bszip.Bookstore.repository.HashtagRepository;
+import com.capstone.bszip.Bookstore.service.dto.HashtagResponse;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+    private final BookstoreRepository bookstoreRepository;
+    private final HashtagRepository hashtagRepository;
+    private final HashtagExtractorService hashtagExtractorService;
+
+    @Transactional
+    public void migrateAllBookstoresToHashtags(){
+        List<Bookstore> bookstores = bookstoreRepository.findAll();
+        for(Bookstore bookstore : bookstores){
+            String description = bookstore.getDescription();
+            if(description!=null && !description.isEmpty()){
+                //해시태그 추출
+                String extractedTag = hashtagExtractorService.extractHashtag(description);
+
+                if (extractedTag != null && !extractedTag.isEmpty()) {
+                    //존재하지 않는 경우
+                    if (!hashtagRepository.existsByTag(extractedTag)) {
+                        Hashtag hashtag = Hashtag.builder()
+                                .bookstore(bookstore)
+                                .tag(extractedTag)
+                                .build();
+                        hashtagRepository.save(hashtag);
+                    }
+                }
+            }
+        }
+    }
+    @PostConstruct
+    public void executeHashtagMigration() {
+        migrateAllBookstoresToHashtags();
+        System.out.println("모든 서점의 해시태그 추출 및 저장이 완료되었습니다.");
+    }
+
+    @Transactional(readOnly = true)
+    public List<HashtagResponse> getRandomHashtagsWithBookstoreId(int count) {
+        return hashtagRepository.findRandomHashtags(count)
+                .stream()
+                .map(hashtag -> new HashtagResponse(
+                        hashtag.getTag(),
+                        hashtag.getBookstore().getBookstoreId()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/capstone/bszip/Bookstore/service/dto/HashtagResponse.java
+++ b/src/main/java/com/capstone/bszip/Bookstore/service/dto/HashtagResponse.java
@@ -1,0 +1,13 @@
+package com.capstone.bszip.Bookstore.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HashtagResponse {
+    private String tag;
+    private Long bookstoreId;
+}


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- HashtagService : openai로 description에서 해시태그 추출 후 db 저장 *@ PostConstruct 실행 후 주석처리해야됨 

- /api/bookstores/hashtag 로 랜덤으로 hashtag 와 연결된 서점 id 반환함 ->클릭시 서점 상세 조회되도록 

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/631d70de-1e52-425c-9973-0c46c439d4e0)



<br/>

## 🔧 앞으로의 과제

- 

  <br/>

## ➕ 이슈 링크

- [Backend #23 ](https://github.com/TEAM-ZIP/Backend/issues/23)

<br/>
